### PR TITLE
feat: 0.1.0 foundation - health endpoints and database check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,5 +13,9 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 Rails:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-06-08
-
 ### Added
 - `GET /health` endpoint returning structured JSON with `ok`/`degraded`/`critical` status, per-check latency, and ISO8601 timestamp
 - `GET /health/live` endpoint returning plain text `OK`/`Service Unavailable` for load balancer liveness probes
@@ -18,5 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ResponseBuilder` for composing JSON responses and HTTP status codes
 - Configuration DSL via `RailsHealthChecks.configure` (`checks`, `timeout`)
 
-[Unreleased]: https://github.com/eclectic-coding/rails_health_checks/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/eclectic-coding/rails_health_checks/releases/tag/v0.1.0
+[Unreleased]: https://github.com/eclectic-coding/rails_health_checks/compare/main...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Initial release of the `rails_health_checks` Rails engine
+## [0.1.0] - 2026-06-08
 
-[Unreleased]: https://github.com/eclectic-coding/rails_health_checks/compare/main...HEAD
+### Added
+- `GET /health` endpoint returning structured JSON with `ok`/`degraded`/`critical` status, per-check latency, and ISO8601 timestamp
+- `GET /health/live` endpoint returning plain text `OK`/`Service Unavailable` for load balancer liveness probes
+- Built-in `database` check using ActiveRecord `SELECT 1` with latency tracking
+- Base `Check` class with `pass`, `warn_with`, `fail_with`, and `measure` helpers
+- `CheckRegistry` for registering and running checks with global timeout and error isolation
+- `ResponseBuilder` for composing JSON responses and HTTP status codes
+- Configuration DSL via `RailsHealthChecks.configure` (`checks`, `timeout`)
+
+[Unreleased]: https://github.com/eclectic-coding/rails_health_checks/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/eclectic-coding/rails_health_checks/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -5,18 +5,19 @@
 [![downloads](https://img.shields.io/gem/dt/rails_health_checks.svg)](https://rubygems.org/gems/rails_health_checks)
 [![ruby](https://img.shields.io/badge/ruby-%3E%3D%203.3-ruby.svg)](https://www.ruby-lang.org)
 [![codecov](https://codecov.io/gh/eclectic-coding/rails_health_checks/branch/main/graph/badge.svg)](https://codecov.io/gh/eclectic-coding/rails_health_checks)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A Rails engine that provides configurable health check endpoints for monitoring application status.
+A Rails engine providing structured, pluggable health check endpoints for monitoring application status. Goes beyond Rails' built-in `/up` endpoint with per-check diagnostics, latency tracking, and a configurable check registry.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add to your Gemfile:
 
 ```ruby
 gem "rails_health_checks"
 ```
 
-Then execute:
+Then run:
 
 ```bash
 bundle install
@@ -28,15 +29,44 @@ Mount the engine in `config/routes.rb`:
 mount RailsHealthChecks::Engine => "/health"
 ```
 
-## Usage
+## Endpoints
 
-Once mounted, the following endpoints are available:
+| Endpoint | Format | Use case |
+|----------|--------|----------|
+| `GET /health` | JSON | Monitoring dashboards, detailed diagnostics |
+| `GET /health/live` | Plain text | Load balancer liveness probes |
 
-| Endpoint       | Description                       |
-|----------------|-----------------------------------|
-| `GET /health`  | Overall application health status |
+HTTP status is `200 OK` when all checks pass, `503 Service Unavailable` otherwise.
 
-Responses return JSON with an HTTP status of `200 OK` (healthy) or `503 Service Unavailable` (unhealthy).
+### JSON response shape
+
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-06-08T20:00:00Z",
+  "checks": {
+    "database": { "status": "ok", "latency_ms": 4 }
+  }
+}
+```
+
+Status values: `ok` | `degraded` | `critical`. Overall status is `critical` if any check is `critical`, `degraded` if any is `degraded`.
+
+## Configuration
+
+```ruby
+# config/initializers/rails_health_checks.rb
+RailsHealthChecks.configure do |config|
+  config.checks  = [:database]  # checks to run (default: [:database])
+  config.timeout = 5            # global timeout per check in seconds (default: 5)
+end
+```
+
+## Built-in checks
+
+| Check | Description |
+|-------|-------------|
+| `:database` | ActiveRecord `SELECT 1` against the primary connection, includes latency |
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,39 +4,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 
 ---
 
-## [0.1.0] — Foundation
-
-> Initial release. Engine boots, one working endpoint, one built-in check, full specs.
-
-**Endpoints:**
-- `GET /health` — JSON response, `200 OK` (healthy) or `503 Service Unavailable` (unhealthy)
-- `GET /health/live` — plain text `OK` / `Service Unavailable` for load balancer liveness probes
-
-**Built-in checks:**
-- `database` — ActiveRecord `SELECT 1` connectivity against the primary connection, includes latency
-
-**Response shape:**
-```json
-{
-  "status": "ok",
-  "timestamp": "2026-06-08T20:00:00Z",
-  "checks": {
-    "database": { "status": "ok", "latency_ms": 4 }
-  }
-}
-```
-Status values: `ok` | `degraded` | `critical`. Overall is `critical` if any check is `critical`; `degraded` if any is `degraded`.
-
-**Configuration DSL:**
-```ruby
-RailsHealthChecks.configure do |config|
-  config.checks  = [:database]  # enable/disable built-in checks
-  config.timeout = 5            # global check timeout in seconds
-end
-```
-
----
-
 ## [0.2.0] — Authentication & Authorization
 
 > Protect health endpoints from public exposure.

--- a/app/controllers/rails_health_checks/health_controller.rb
+++ b/app/controllers/rails_health_checks/health_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  class HealthController < ApplicationController
+    def show
+      builder = ResponseBuilder.new(run_checks)
+      render json: builder.to_json, status: builder.http_status
+    end
+
+    def live
+      builder = ResponseBuilder.new(run_checks)
+      if builder.overall_status == 'ok'
+        render plain: 'OK', status: :ok
+      else
+        render plain: 'Service Unavailable', status: :service_unavailable
+      end
+    end
+
+    private
+
+    def run_checks
+      config = RailsHealthChecks.configuration
+      checks = CheckRegistry.build(config.checks)
+      CheckRegistry.run(checks, timeout: config.timeout)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-RailsHealthChecks::Engine.routes.draw do # rubocop:disable Lint/EmptyBlock
+RailsHealthChecks::Engine.routes.draw do
+  get '/',     to: 'health#show', as: :health
+  get '/live', to: 'health#live', as: :health_live
 end

--- a/lib/rails_health_checks.rb
+++ b/lib/rails_health_checks.rb
@@ -2,7 +2,20 @@
 
 require 'rails_health_checks/version'
 require 'rails_health_checks/engine'
+require 'rails_health_checks/configuration'
+require 'rails_health_checks/check'
+require 'rails_health_checks/checks/database_check'
+require 'rails_health_checks/check_registry'
+require 'rails_health_checks/response_builder'
 
 module RailsHealthChecks
-  # Your code goes here...
+  class << self
+    def configure
+      yield(configuration)
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
 end

--- a/lib/rails_health_checks/check.rb
+++ b/lib/rails_health_checks/check.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  class Check
+    attr_reader :status, :message, :latency_ms
+
+    def call
+      raise NotImplementedError, "#{self.class} must implement #call"
+    end
+
+    private
+
+    def pass(message = nil)
+      @status = 'ok'
+      @message = message
+    end
+
+    def warn_with(message)
+      @status = 'degraded'
+      @message = message
+    end
+
+    def fail_with(message)
+      @status = 'critical'
+      @message = message
+    end
+
+    def measure
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+      @latency_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round
+    end
+  end
+end

--- a/lib/rails_health_checks/check_registry.rb
+++ b/lib/rails_health_checks/check_registry.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'timeout'
+
+module RailsHealthChecks
+  class CheckRegistry
+    BUILT_INS = {
+      database: -> { Checks::DatabaseCheck.new }
+    }.freeze
+
+    def self.build(check_names)
+      check_names.each_with_object({}) do |name, hash|
+        factory = BUILT_INS.fetch(name) do
+          raise ArgumentError, "Unknown check: #{name}. Available: #{BUILT_INS.keys.join(', ')}"
+        end
+        hash[name] = factory.call
+      end
+    end
+
+    def self.run(checks, timeout:)
+      checks.transform_values { |check| run_check(check, timeout: timeout) }
+    end
+
+    def self.run_check(check, timeout:)
+      Timeout.timeout(timeout) { check.call }
+      check
+    rescue Timeout::Error
+      mark_critical(check, 'timed out')
+    rescue StandardError => e
+      mark_critical(check, e.message)
+    end
+
+    def self.mark_critical(check, message)
+      check.instance_variable_set(:@status, 'critical')
+      check.instance_variable_set(:@message, message)
+      check
+    end
+
+    private_class_method :run_check, :mark_critical
+  end
+end

--- a/lib/rails_health_checks/checks/database_check.rb
+++ b/lib/rails_health_checks/checks/database_check.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  module Checks
+    class DatabaseCheck < Check
+      def call
+        measure { ActiveRecord::Base.connection.execute('SELECT 1') }
+        pass
+      rescue StandardError => e
+        fail_with(e.message)
+      end
+    end
+  end
+end

--- a/lib/rails_health_checks/configuration.rb
+++ b/lib/rails_health_checks/configuration.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  class Configuration
+    attr_accessor :checks, :timeout
+
+    def initialize
+      @checks = [:database]
+      @timeout = 5
+    end
+  end
+end

--- a/lib/rails_health_checks/response_builder.rb
+++ b/lib/rails_health_checks/response_builder.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  class ResponseBuilder
+    def initialize(results)
+      @results = results
+    end
+
+    def overall_status
+      statuses = @results.values.map(&:status)
+      if statuses.include?('critical')
+        'critical'
+      elsif statuses.include?('degraded')
+        'degraded'
+      else
+        'ok'
+      end
+    end
+
+    def to_json(*)
+      checks_hash = @results.transform_values do |check|
+        result = { status: check.status }
+        result[:latency_ms] = check.latency_ms if check.latency_ms
+        result[:message] = check.message if check.message
+        result
+      end
+
+      { status: overall_status, timestamp: Time.now.utc.iso8601, checks: checks_hash }.to_json
+    end
+
+    def http_status
+      overall_status == 'ok' ? :ok : :service_unavailable
+    end
+  end
+end

--- a/spec/lib/rails_health_checks/checks/database_check_spec.rb
+++ b/spec/lib/rails_health_checks/checks/database_check_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RailsHealthChecks::Checks::DatabaseCheck do
+  subject(:check) { described_class.new }
+
+  describe '#call' do
+    context 'when the database is reachable' do
+      it 'sets status to ok' do
+        check.call
+        expect(check.status).to eq('ok')
+      end
+
+      it 'records latency in milliseconds' do
+        check.call
+        expect(check.latency_ms).to be_a(Integer)
+        expect(check.latency_ms).to be >= 0
+      end
+    end
+
+    context 'when the database raises an error' do
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:execute).and_raise(StandardError, 'DB unavailable')
+      end
+
+      it 'sets status to critical' do
+        check.call
+        expect(check.status).to eq('critical')
+      end
+
+      it 'records the error message' do
+        check.call
+        expect(check.message).to eq('DB unavailable')
+      end
+    end
+  end
+end

--- a/spec/lib/rails_health_checks/response_builder_spec.rb
+++ b/spec/lib/rails_health_checks/response_builder_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RailsHealthChecks::ResponseBuilder do
+  def make_check(status, latency_ms: nil, message: nil)
+    check = RailsHealthChecks::Check.new
+    check.instance_variable_set(:@status, status)
+    check.instance_variable_set(:@latency_ms, latency_ms)
+    check.instance_variable_set(:@message, message)
+    check
+  end
+
+  describe '#overall_status' do
+    it 'returns ok when all checks pass' do
+      results = { database: make_check('ok') }
+      expect(described_class.new(results).overall_status).to eq('ok')
+    end
+
+    it 'returns degraded when any check is degraded' do
+      results = { database: make_check('ok'), cache: make_check('degraded') }
+      expect(described_class.new(results).overall_status).to eq('degraded')
+    end
+
+    it 'returns critical when any check is critical' do
+      results = { database: make_check('critical'), cache: make_check('degraded') }
+      expect(described_class.new(results).overall_status).to eq('critical')
+    end
+  end
+
+  describe '#http_status' do
+    it 'returns :ok when overall status is ok' do
+      results = { database: make_check('ok') }
+      expect(described_class.new(results).http_status).to eq(:ok)
+    end
+
+    it 'returns :service_unavailable when overall status is not ok' do
+      results = { database: make_check('critical') }
+      expect(described_class.new(results).http_status).to eq(:service_unavailable)
+    end
+  end
+
+  describe '#to_json' do
+    it 'includes status, timestamp, and checks' do
+      results = { database: make_check('ok', latency_ms: 5) }
+      json = JSON.parse(described_class.new(results).to_json)
+
+      expect(json['status']).to eq('ok')
+      expect(json['timestamp']).to match(/\d{4}-\d{2}-\d{2}T/)
+      expect(json['checks']['database']['status']).to eq('ok')
+      expect(json['checks']['database']['latency_ms']).to eq(5)
+    end
+
+    it 'omits nil latency and message fields' do
+      results = { database: make_check('ok') }
+      json = JSON.parse(described_class.new(results).to_json)
+
+      expect(json['checks']['database']).not_to have_key('latency_ms')
+      expect(json['checks']['database']).not_to have_key('message')
+    end
+
+    it 'includes message when present' do
+      results = { database: make_check('critical', message: 'DB down') }
+      json = JSON.parse(described_class.new(results).to_json)
+
+      expect(json['checks']['database']['message']).to eq('DB down')
+    end
+  end
+end

--- a/spec/requests/rails_health_checks/health_spec.rb
+++ b/spec/requests/rails_health_checks/health_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Health endpoints', type: :request do
+  describe 'GET /health' do
+    context 'when all checks pass' do
+      it 'returns 200 with JSON body' do
+        get '/health'
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include('application/json')
+
+        json = response.parsed_body
+        expect(json['status']).to eq('ok')
+        expect(json['timestamp']).to be_present
+        expect(json['checks']['database']['status']).to eq('ok')
+        expect(json['checks']['database']['latency_ms']).to be_a(Integer)
+      end
+    end
+
+    context 'when the database check fails' do
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:execute).and_raise(StandardError, 'connection refused')
+      end
+
+      it 'returns 503 with critical status' do
+        get '/health'
+
+        expect(response).to have_http_status(:service_unavailable)
+
+        json = response.parsed_body
+        expect(json['status']).to eq('critical')
+        expect(json['checks']['database']['status']).to eq('critical')
+        expect(json['checks']['database']['message']).to eq('connection refused')
+      end
+    end
+  end
+
+  describe 'GET /health/live' do
+    context 'when all checks pass' do
+      it 'returns 200 with OK text' do
+        get '/health/live'
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq('OK')
+      end
+    end
+
+    context 'when the database check fails' do
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:execute).and_raise(StandardError, 'connection refused')
+      end
+
+      it 'returns 503 with Service Unavailable text' do
+        get '/health/live'
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response.body).to eq('Service Unavailable')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implements `GET /health` returning structured JSON with `ok`/`degraded`/`critical` status and per-check latency
- Implements `GET /health/live` returning plain text `OK`/`Service Unavailable` for load balancer liveness probes
- Adds built-in `database` check (ActiveRecord `SELECT 1` with latency tracking)
- Adds base `Check` class, `CheckRegistry` (with timeout support), `ResponseBuilder`, and `Configuration` DSL
- 16 RSpec examples covering both endpoints and core unit classes

## Test plan

- [x] `bundle exec rspec` — 16 examples, 0 failures
- [x] `bundle exec rake lint` — no offenses
- [x] CI passing on Ruby 3.3, 3.4, 4.0

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)