### PR TITLE
feat: add cache check via Rails.cache read/write probe (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Built-in `cache` check using `Rails.cache` read/write probe; works with Redis, Memcached, or in-process store
+
 ## [0.2.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Status values: `ok` | `degraded` | `critical`. Overall status is `critical` if a
 ```ruby
 # config/initializers/rails_health_checks.rb
 RailsHealthChecks.configure do |config|
-  config.checks  = [:database]  # checks to run (default: [:database])
+  config.checks  = [:database, :cache]  # checks to run (default: [:database])
   config.timeout = 5            # global timeout per check in seconds (default: 5)
 end
 ```
@@ -126,6 +126,7 @@ The block receives the `ActionDispatch::Request` object and must return a truthy
 | Check | Description |
 |-------|-------------|
 | `:database` | ActiveRecord `SELECT 1` against the primary connection, includes latency |
+| `:cache` | `Rails.cache` read/write probe; works with Redis, Memcached, or in-process store |
 
 [↑ Back to top](#table-of-contents)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 > Cover the most common production dependencies.
 
 **Built-in checks:**
-- `cache` — reads/writes via `Rails.cache`; works with Redis, Memcached, or in-process store
 - `sidekiq` — Sidekiq connectivity and configurable queue depth threshold
 - `solid_queue` — Solid Queue connectivity and pending job count
 - `good_job` — GoodJob queue latency check

--- a/lib/rails_health_checks.rb
+++ b/lib/rails_health_checks.rb
@@ -6,6 +6,7 @@ require "rails_health_checks/configuration"
 require "rails_health_checks/authentication"
 require "rails_health_checks/check"
 require "rails_health_checks/checks/database_check"
+require "rails_health_checks/checks/cache_check"
 require "rails_health_checks/check_registry"
 require "rails_health_checks/response_builder"
 

--- a/lib/rails_health_checks/check_registry.rb
+++ b/lib/rails_health_checks/check_registry.rb
@@ -5,7 +5,8 @@ require "timeout"
 module RailsHealthChecks
   class CheckRegistry
     BUILT_INS = {
-      database: -> { Checks::DatabaseCheck.new }
+      database: -> { Checks::DatabaseCheck.new },
+      cache:    -> { Checks::CacheCheck.new }
     }.freeze
 
     def self.build(check_names)

--- a/lib/rails_health_checks/checks/cache_check.rb
+++ b/lib/rails_health_checks/checks/cache_check.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  module Checks
+    class CacheCheck < Check
+      PROBE_KEY = "rails_health_checks:cache_probe"
+      PROBE_VALUE = "ok"
+
+      def call
+        measure do
+          Rails.cache.write(PROBE_KEY, PROBE_VALUE, expires_in: 10)
+          result = Rails.cache.read(PROBE_KEY)
+          raise "unexpected value: #{result.inspect}" unless result == PROBE_VALUE
+        end
+        pass
+      rescue StandardError => e
+        fail_with(e.message)
+      end
+    end
+  end
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -9,5 +9,6 @@ module Dummy
   class Application < Rails::Application
     config.load_defaults 8.1
     config.eager_load = false
+    config.cache_store = :memory_store
   end
 end

--- a/spec/lib/rails_health_checks/check_registry_spec.rb
+++ b/spec/lib/rails_health_checks/check_registry_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe RailsHealthChecks::CheckRegistry do
       expect(result[:database]).to be_a(RailsHealthChecks::Checks::DatabaseCheck)
     end
 
+    it "builds a cache check" do
+      result = described_class.build([:cache])
+      expect(result[:cache]).to be_a(RailsHealthChecks::Checks::CacheCheck)
+    end
+
     it "raises ArgumentError for unknown check names" do
       expect { described_class.build([:unknown]) }
         .to raise_error(ArgumentError, /Unknown check: unknown/)

--- a/spec/lib/rails_health_checks/checks/cache_check_spec.rb
+++ b/spec/lib/rails_health_checks/checks/cache_check_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RailsHealthChecks::Checks::CacheCheck do
+  subject(:check) { described_class.new }
+
+  describe "#call" do
+    context "when the cache is available" do
+      it "sets status to ok" do
+        check.call
+        expect(check.status).to eq("ok")
+      end
+
+      it "records latency in milliseconds" do
+        check.call
+        expect(check.latency_ms).to be_a(Integer)
+        expect(check.latency_ms).to be >= 0
+      end
+    end
+
+    context "when the cache write raises an error" do
+      before { allow(Rails.cache).to receive(:write).and_raise(StandardError, "cache unavailable") }
+
+      it "sets status to critical" do
+        check.call
+        expect(check.status).to eq("critical")
+      end
+
+      it "records the error message" do
+        check.call
+        expect(check.message).to eq("cache unavailable")
+      end
+    end
+
+    context "when the cache read returns an unexpected value" do
+      before do
+        allow(Rails.cache).to receive(:write)
+        allow(Rails.cache).to receive(:read).and_return(nil)
+      end
+
+      it "sets status to critical" do
+        check.call
+        expect(check.status).to eq("critical")
+      end
+
+      it "records an unexpected value message" do
+        check.call
+        expect(check.message).to include("unexpected value")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #4

## Summary

- Add built-in `:cache` check using `Rails.cache` write/read probe
- Works with any configured cache store (Redis, Memcached, in-process `:memory_store`)
- Configure dummy app with `:memory_store` for test isolation
- Updated CHANGELOG, ROADMAP (cache bullet removed from 0.3.0), and README

## Test plan

- [ ] 42 examples, 0 failures
- [ ] Line coverage: 100% (151 / 151)
- [ ] RuboCop: no offenses
- [ ] Happy path, write error, and unexpected read value all covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)