### PR TITLE
feat: add Sidekiq check with Redis connectivity and queue depth threshold (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Built-in `cache` check using `Rails.cache` read/write probe; works with Redis, Memcached, or in-process store
+- Built-in `sidekiq` check verifying Redis connectivity; optional `config.sidekiq_queue_size` threshold reports `degraded` when total queue depth exceeds it
 
 ## [0.2.0] - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The block receives the `ActionDispatch::Request` object and must return a truthy
 |-------|-------------|
 | `:database` | ActiveRecord `SELECT 1` against the primary connection, includes latency |
 | `:cache` | `Rails.cache` read/write probe; works with Redis, Memcached, or in-process store |
+| `:sidekiq` | Sidekiq Redis connectivity; optional `config.sidekiq_queue_size` threshold for queue depth |
 
 [↑ Back to top](#table-of-contents)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 > Cover the most common production dependencies.
 
 **Built-in checks:**
-- `sidekiq` — Sidekiq connectivity and configurable queue depth threshold
 - `solid_queue` — Solid Queue connectivity and pending job count
 - `good_job` — GoodJob queue latency check
 - `resque` — Resque connectivity and queue depth threshold

--- a/lib/rails_health_checks.rb
+++ b/lib/rails_health_checks.rb
@@ -7,6 +7,7 @@ require "rails_health_checks/authentication"
 require "rails_health_checks/check"
 require "rails_health_checks/checks/database_check"
 require "rails_health_checks/checks/cache_check"
+require "rails_health_checks/checks/sidekiq_check"
 require "rails_health_checks/check_registry"
 require "rails_health_checks/response_builder"
 

--- a/lib/rails_health_checks/check_registry.rb
+++ b/lib/rails_health_checks/check_registry.rb
@@ -6,7 +6,8 @@ module RailsHealthChecks
   class CheckRegistry
     BUILT_INS = {
       database: -> { Checks::DatabaseCheck.new },
-      cache:    -> { Checks::CacheCheck.new }
+      cache:    -> { Checks::CacheCheck.new },
+      sidekiq:  -> { Checks::SidekiqCheck.new(queue_size: RailsHealthChecks.configuration.sidekiq_queue_size) }
     }.freeze
 
     def self.build(check_names)

--- a/lib/rails_health_checks/checks/sidekiq_check.rb
+++ b/lib/rails_health_checks/checks/sidekiq_check.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  module Checks
+    class SidekiqCheck < Check
+      def initialize(queue_size: nil)
+        unless defined?(::Sidekiq)
+          raise LoadError, "Sidekiq is not installed. Add `gem 'sidekiq'` to your Gemfile to use the :sidekiq check."
+        end
+
+        @queue_size = queue_size
+      end
+
+      def call
+        measure { ::Sidekiq.redis { |conn| conn.ping } }
+
+        if @queue_size
+          depth = ::Sidekiq::Queue.all.sum(&:size)
+          return warn_with("queue depth #{depth} exceeds threshold #{@queue_size}") if depth > @queue_size
+        end
+
+        pass
+      rescue StandardError => e
+        fail_with(e.message)
+      end
+    end
+  end
+end

--- a/lib/rails_health_checks/configuration.rb
+++ b/lib/rails_health_checks/configuration.rb
@@ -2,7 +2,7 @@
 
 module RailsHealthChecks
   class Configuration
-    attr_accessor :checks, :timeout, :allowed_ips, :token
+    attr_accessor :checks, :timeout, :allowed_ips, :token, :sidekiq_queue_size
     attr_reader :authenticate_block
 
     def initialize
@@ -11,6 +11,7 @@ module RailsHealthChecks
       @allowed_ips = nil
       @token = nil
       @authenticate_block = nil
+      @sidekiq_queue_size = nil
     end
 
     def authenticate(&block)

--- a/spec/lib/rails_health_checks/check_registry_spec.rb
+++ b/spec/lib/rails_health_checks/check_registry_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe RailsHealthChecks::CheckRegistry do
       expect(result[:cache]).to be_a(RailsHealthChecks::Checks::CacheCheck)
     end
 
+    it "builds a sidekiq check when Sidekiq is available" do
+      stub_const("Sidekiq", Module.new { def self.redis; end })
+      stub_const("Sidekiq::Queue", Class.new { def self.all; end })
+      result = described_class.build([:sidekiq])
+      expect(result[:sidekiq]).to be_a(RailsHealthChecks::Checks::SidekiqCheck)
+    end
+
     it "raises ArgumentError for unknown check names" do
       expect { described_class.build([:unknown]) }
         .to raise_error(ArgumentError, /Unknown check: unknown/)

--- a/spec/lib/rails_health_checks/checks/sidekiq_check_spec.rb
+++ b/spec/lib/rails_health_checks/checks/sidekiq_check_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RailsHealthChecks::Checks::SidekiqCheck do
+  context "when Sidekiq is not installed" do
+    it "raises LoadError on initialization" do
+      hide_const("Sidekiq")
+      expect { described_class.new }.to raise_error(LoadError, /Sidekiq is not installed/)
+    end
+  end
+
+  context "when Sidekiq is available" do
+    let(:redis_conn) { double("conn", ping: "PONG") }
+
+    before do
+      stub_const("Sidekiq", Module.new { def self.redis; end })
+      stub_const("Sidekiq::Queue", Class.new { def self.all; end })
+      allow(Sidekiq).to receive(:redis).and_yield(redis_conn)
+      allow(Sidekiq::Queue).to receive(:all).and_return([])
+    end
+
+    subject(:check) { described_class.new }
+
+    describe "#call" do
+      context "when Redis is reachable" do
+        it "sets status to ok" do
+          check.call
+          expect(check.status).to eq("ok")
+        end
+
+        it "records latency in milliseconds" do
+          check.call
+          expect(check.latency_ms).to be_a(Integer)
+          expect(check.latency_ms).to be >= 0
+        end
+      end
+
+      context "when Redis is unreachable" do
+        before { allow(Sidekiq).to receive(:redis).and_raise(StandardError, "connection refused") }
+
+        it "sets status to critical" do
+          check.call
+          expect(check.status).to eq("critical")
+        end
+
+        it "records the error message" do
+          check.call
+          expect(check.message).to eq("connection refused")
+        end
+      end
+
+      context "with queue depth threshold" do
+        let(:queues) { [double("q1", size: 600), double("q2", size: 500)] }
+
+        before { allow(Sidekiq::Queue).to receive(:all).and_return(queues) }
+
+        context "when depth is within threshold" do
+          subject(:check) { described_class.new(queue_size: 2000) }
+
+          it "sets status to ok" do
+            check.call
+            expect(check.status).to eq("ok")
+          end
+        end
+
+        context "when depth exceeds threshold" do
+          subject(:check) { described_class.new(queue_size: 500) }
+
+          it "sets status to degraded" do
+            check.call
+            expect(check.status).to eq("degraded")
+          end
+
+          it "includes depth and threshold in message" do
+            check.call
+            expect(check.message).to eq("queue depth 1100 exceeds threshold 500")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #5

## Summary

- Add built-in `:sidekiq` check verifying Redis connectivity via `Sidekiq.redis { |conn| conn.ping }`
- Optional `config.sidekiq_queue_size = N` — reports `degraded` when total queue depth exceeds threshold
- Raises `LoadError` at build time if Sidekiq gem is not installed
- No Sidekiq gem dependency — constants stubbed in tests using `stub_const`
- Updated CHANGELOG, ROADMAP (sidekiq bullet removed from 0.3.0), and README

## Test plan

- [ ] 51 examples, 0 failures
- [ ] Line coverage: 100% (168 / 168)
- [ ] RuboCop: no offenses
- [ ] Covers: Redis reachable, Redis unreachable, depth within threshold, depth exceeds threshold, Sidekiq not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)