### PR TITLE
feat: add GoodJob check with queue latency threshold (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Built-in `cache` check using `Rails.cache` read/write probe; works with Redis, Memcached, or in-process store
 - Built-in `sidekiq` check verifying Redis connectivity; optional `config.sidekiq_queue_size` threshold reports `degraded` when total queue depth exceeds it
 - Built-in `solid_queue` check verifying DB connectivity via `SolidQueue::ReadyExecution.count`; optional `config.solid_queue_job_count` threshold reports `degraded` when pending jobs exceed it
+- Built-in `good_job` check querying oldest pending `GoodJob::Job`; optional `config.good_job_latency` (seconds) reports `degraded` when queue latency exceeds it
 
 ## [0.2.0] - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The block receives the `ActionDispatch::Request` object and must return a truthy
 | `:cache` | `Rails.cache` read/write probe; works with Redis, Memcached, or in-process store |
 | `:sidekiq` | Sidekiq Redis connectivity; optional `config.sidekiq_queue_size` threshold for queue depth |
 | `:solid_queue` | Solid Queue DB connectivity; optional `config.solid_queue_job_count` threshold for pending jobs |
+| `:good_job` | GoodJob queue latency; optional `config.good_job_latency` (seconds) threshold for oldest pending job |
 
 [↑ Back to top](#table-of-contents)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 > Cover the most common production dependencies.
 
 **Built-in checks:**
-- `good_job` — GoodJob queue latency check
 - `resque` — Resque connectivity and queue depth threshold
 
 Checks for non-installed adapters raise a descriptive error at boot, not at request time.

--- a/lib/rails_health_checks.rb
+++ b/lib/rails_health_checks.rb
@@ -9,6 +9,7 @@ require "rails_health_checks/checks/database_check"
 require "rails_health_checks/checks/cache_check"
 require "rails_health_checks/checks/sidekiq_check"
 require "rails_health_checks/checks/solid_queue_check"
+require "rails_health_checks/checks/good_job_check"
 require "rails_health_checks/check_registry"
 require "rails_health_checks/response_builder"
 

--- a/lib/rails_health_checks/check_registry.rb
+++ b/lib/rails_health_checks/check_registry.rb
@@ -8,7 +8,8 @@ module RailsHealthChecks
       database: -> { Checks::DatabaseCheck.new },
       cache:    -> { Checks::CacheCheck.new },
       sidekiq:     -> { Checks::SidekiqCheck.new(queue_size: RailsHealthChecks.configuration.sidekiq_queue_size) },
-      solid_queue: -> { Checks::SolidQueueCheck.new(job_count: RailsHealthChecks.configuration.solid_queue_job_count) }
+      solid_queue: -> { Checks::SolidQueueCheck.new(job_count: RailsHealthChecks.configuration.solid_queue_job_count) },
+      good_job:    -> { Checks::GoodJobCheck.new(latency: RailsHealthChecks.configuration.good_job_latency) }
     }.freeze
 
     def self.build(check_names)

--- a/lib/rails_health_checks/checks/good_job_check.rb
+++ b/lib/rails_health_checks/checks/good_job_check.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  module Checks
+    class GoodJobCheck < Check
+      def initialize(latency: nil)
+        unless defined?(::GoodJob)
+          raise LoadError, "GoodJob is not installed. Add `gem 'good_job'` to your Gemfile to use the :good_job check."
+        end
+
+        @latency = latency
+      end
+
+      def call
+        measure do
+          oldest = ::GoodJob::Job
+            .where(finished_at: nil, performed_at: nil)
+            .minimum(:created_at)
+
+          if @latency && oldest
+            age = (Time.current - oldest).to_i
+            return warn_with("queue latency #{age}s exceeds threshold #{@latency}s") if age > @latency
+          end
+        end
+        pass
+      rescue StandardError => e
+        fail_with(e.message)
+      end
+    end
+  end
+end

--- a/lib/rails_health_checks/configuration.rb
+++ b/lib/rails_health_checks/configuration.rb
@@ -2,7 +2,7 @@
 
 module RailsHealthChecks
   class Configuration
-    attr_accessor :checks, :timeout, :allowed_ips, :token, :sidekiq_queue_size, :solid_queue_job_count
+    attr_accessor :checks, :timeout, :allowed_ips, :token, :sidekiq_queue_size, :solid_queue_job_count, :good_job_latency
     attr_reader :authenticate_block
 
     def initialize
@@ -13,6 +13,7 @@ module RailsHealthChecks
       @authenticate_block = nil
       @sidekiq_queue_size = nil
       @solid_queue_job_count = nil
+      @good_job_latency = nil
     end
 
     def authenticate(&block)

--- a/spec/lib/rails_health_checks/check_registry_spec.rb
+++ b/spec/lib/rails_health_checks/check_registry_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe RailsHealthChecks::CheckRegistry do
       expect(result[:cache]).to be_a(RailsHealthChecks::Checks::CacheCheck)
     end
 
+    it "builds a good_job check when GoodJob is available" do
+      stub_const("GoodJob", Module.new)
+      stub_const("GoodJob::Job", Class.new { def self.where(*); end })
+      result = described_class.build([:good_job])
+      expect(result[:good_job]).to be_a(RailsHealthChecks::Checks::GoodJobCheck)
+    end
+
     it "builds a solid_queue check when SolidQueue is available" do
       stub_const("SolidQueue", Module.new)
       stub_const("SolidQueue::ReadyExecution", Class.new { def self.count; end })

--- a/spec/lib/rails_health_checks/checks/good_job_check_spec.rb
+++ b/spec/lib/rails_health_checks/checks/good_job_check_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RailsHealthChecks::Checks::GoodJobCheck do
+  context "when GoodJob is not installed" do
+    it "raises LoadError on initialization" do
+      hide_const("GoodJob")
+      expect { described_class.new }.to raise_error(LoadError, /GoodJob is not installed/)
+    end
+  end
+
+  context "when GoodJob is available" do
+    let(:job_relation) { instance_double("GoodJob::Job::ActiveRecord_Relation") }
+
+    before do
+      stub_const("GoodJob", Module.new)
+      stub_const("GoodJob::Job", Class.new do
+        def self.where(*); end
+      end)
+      allow(GoodJob::Job).to receive(:where).and_return(job_relation)
+      allow(job_relation).to receive(:where).and_return(job_relation)
+      allow(job_relation).to receive(:minimum).and_return(nil)
+    end
+
+    subject(:check) { described_class.new }
+
+    describe "#call" do
+      context "when there are no pending jobs" do
+        it "sets status to ok" do
+          check.call
+          expect(check.status).to eq("ok")
+        end
+
+        it "records latency in milliseconds" do
+          check.call
+          expect(check.latency_ms).to be_a(Integer)
+          expect(check.latency_ms).to be >= 0
+        end
+      end
+
+      context "when the database raises an error" do
+        before { allow(GoodJob::Job).to receive(:where).and_raise(StandardError, "DB unavailable") }
+
+        it "sets status to critical" do
+          check.call
+          expect(check.status).to eq("critical")
+        end
+
+        it "records the error message" do
+          check.call
+          expect(check.message).to eq("DB unavailable")
+        end
+      end
+
+      context "with latency threshold" do
+        let(:old_job_time) { Time.current - 120 }
+
+        before { allow(job_relation).to receive(:minimum).and_return(old_job_time) }
+
+        context "when latency is within threshold" do
+          subject(:check) { described_class.new(latency: 300) }
+
+          it "sets status to ok" do
+            check.call
+            expect(check.status).to eq("ok")
+          end
+        end
+
+        context "when latency exceeds threshold" do
+          subject(:check) { described_class.new(latency: 60) }
+
+          it "sets status to degraded" do
+            check.call
+            expect(check.status).to eq("degraded")
+          end
+
+          it "includes age and threshold in message" do
+            check.call
+            expect(check.message).to match(/queue latency \d+s exceeds threshold 60s/)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #7

## Summary

- Add built-in `:good_job` check querying `GoodJob::Job` for the oldest pending (not started, not finished) job
- Optional `config.good_job_latency = N` (seconds) — reports `degraded` when oldest job age exceeds threshold
- Raises `LoadError` at build time if GoodJob gem is not installed
- No GoodJob gem dependency — constants stubbed in tests
- Updated CHANGELOG, ROADMAP (good_job bullet removed from 0.3.0), and README

## Test plan

- [ ] 69 examples, 0 failures
- [ ] Line coverage: 100% (203 / 203)
- [ ] RuboCop: no offenses
- [ ] Covers: no pending jobs, DB error, latency within threshold, latency exceeds threshold, GoodJob not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)