### PR TITLE
feat: add disk check with free space warn/critical thresholds (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - Unreleased
+
+### Added
+- Built-in `disk` check using `df -Pk` to measure free disk bytes; optional `config.disk_warn_threshold` reports `degraded` and `config.disk_critical_threshold` reports `critical` when free space falls below the configured byte thresholds; `config.disk_path` selects the mount point to check (default: `/`)
+
 ## [0.3.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The block receives the `ActionDispatch::Request` object and must return a truthy
 | `:solid_queue` | Solid Queue DB connectivity; optional `config.solid_queue_job_count` threshold for pending jobs |
 | `:good_job` | GoodJob queue latency; optional `config.good_job_latency` (seconds) threshold for oldest pending job |
 | `:resque` | Resque Redis connectivity; optional `config.resque_queue_size` threshold for total queue depth |
+| `:disk` | Free disk bytes via `df`; optional `config.disk_warn_threshold` / `config.disk_critical_threshold` (bytes) and `config.disk_path` (default: `/`) |
 
 [↑ Back to top](#table-of-contents)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 > Host-level visibility and protection against hammering dependencies on every request.
 
 **Built-in checks:**
-- `disk_space` — free disk bytes vs configurable warn/critical thresholds
+- ~~`disk_space` — free disk bytes vs configurable warn/critical thresholds~~ ✓ shipped as `:disk`
 - `memory` — process RSS vs configurable threshold
 - `http` — arbitrary external URL with configurable expected status code
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 > Host-level visibility and protection against hammering dependencies on every request.
 
 **Built-in checks:**
-- ~~`disk_space` — free disk bytes vs configurable warn/critical thresholds~~ ✓ shipped as `:disk`
 - `memory` — process RSS vs configurable threshold
 - `http` — arbitrary external URL with configurable expected status code
 

--- a/lib/rails_health_checks.rb
+++ b/lib/rails_health_checks.rb
@@ -11,6 +11,7 @@ require "rails_health_checks/checks/sidekiq_check"
 require "rails_health_checks/checks/solid_queue_check"
 require "rails_health_checks/checks/good_job_check"
 require "rails_health_checks/checks/resque_check"
+require "rails_health_checks/checks/disk_check"
 require "rails_health_checks/check_registry"
 require "rails_health_checks/response_builder"
 

--- a/lib/rails_health_checks/check_registry.rb
+++ b/lib/rails_health_checks/check_registry.rb
@@ -10,7 +10,12 @@ module RailsHealthChecks
       sidekiq:     -> { Checks::SidekiqCheck.new(queue_size: RailsHealthChecks.configuration.sidekiq_queue_size) },
       solid_queue: -> { Checks::SolidQueueCheck.new(job_count: RailsHealthChecks.configuration.solid_queue_job_count) },
       good_job:    -> { Checks::GoodJobCheck.new(latency: RailsHealthChecks.configuration.good_job_latency) },
-      resque:      -> { Checks::ResqueCheck.new(queue_size: RailsHealthChecks.configuration.resque_queue_size) }
+      resque:      -> { Checks::ResqueCheck.new(queue_size: RailsHealthChecks.configuration.resque_queue_size) },
+      disk:        -> { Checks::DiskCheck.new(
+        warn_threshold:     RailsHealthChecks.configuration.disk_warn_threshold,
+        critical_threshold: RailsHealthChecks.configuration.disk_critical_threshold,
+        path:               RailsHealthChecks.configuration.disk_path
+      ) }
     }.freeze
 
     def self.build(check_names)

--- a/lib/rails_health_checks/checks/disk_check.rb
+++ b/lib/rails_health_checks/checks/disk_check.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module RailsHealthChecks
+  module Checks
+    class DiskCheck < Check
+      def initialize(warn_threshold: nil, critical_threshold: nil, path: "/")
+        @warn_threshold = warn_threshold
+        @critical_threshold = critical_threshold
+        @path = path
+      end
+
+      def call
+        free = nil
+        measure { free = free_bytes }
+
+        if @critical_threshold && free < @critical_threshold
+          return fail_with("free disk space #{free} bytes below critical threshold #{@critical_threshold} bytes")
+        end
+
+        if @warn_threshold && free < @warn_threshold
+          return warn_with("free disk space #{free} bytes below warn threshold #{@warn_threshold} bytes")
+        end
+
+        pass
+      rescue StandardError => e
+        fail_with(e.message)
+      end
+
+      private
+
+      def free_bytes
+        out, _, status = Open3.capture3("df", "-Pk", @path.to_s)
+        raise "df command failed with exit status #{status.exitstatus}" unless status.success?
+
+        parts = out.split("\n").last.split
+        parts[3].to_i * 1024
+      end
+    end
+  end
+end

--- a/lib/rails_health_checks/configuration.rb
+++ b/lib/rails_health_checks/configuration.rb
@@ -3,7 +3,7 @@
 module RailsHealthChecks
   class Configuration
     attr_accessor :checks, :timeout, :allowed_ips, :token, :sidekiq_queue_size, :solid_queue_job_count, :good_job_latency,
-                  :resque_queue_size
+                  :resque_queue_size, :disk_warn_threshold, :disk_critical_threshold, :disk_path
     attr_reader :authenticate_block
 
     def initialize
@@ -16,6 +16,9 @@ module RailsHealthChecks
       @solid_queue_job_count = nil
       @good_job_latency = nil
       @resque_queue_size = nil
+      @disk_warn_threshold = nil
+      @disk_critical_threshold = nil
+      @disk_path = "/"
     end
 
     def authenticate(&block)

--- a/spec/lib/rails_health_checks/checks/disk_check_spec.rb
+++ b/spec/lib/rails_health_checks/checks/disk_check_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "open3"
+
+RSpec.describe RailsHealthChecks::Checks::DiskCheck do
+  # df -Pk output: Filesystem  1024-blocks  Used  Available  Capacity%  Mounted-on
+  def df_output(available_kb)
+    "Filesystem     1024-blocks      Used Available Capacity Mounted on\n" \
+      "/dev/disk1     244140625  87890625 #{available_kb}      37% /\n"
+  end
+
+  describe "#call" do
+    context "when df succeeds" do
+      let(:available_kb) { 5_000_000 }  # ~4.8 GB free
+      let(:free_bytes) { available_kb * 1024 }
+
+      before do
+        allow(Open3).to receive(:capture3).with("df", "-Pk", "/")
+          .and_return([df_output(available_kb), "", instance_double(Process::Status, success?: true, exitstatus: 0)])
+      end
+
+      subject(:check) { described_class.new }
+
+      it "sets status to ok" do
+        check.call
+        expect(check.status).to eq("ok")
+      end
+
+      it "records latency in milliseconds" do
+        check.call
+        expect(check.latency_ms).to be_a(Integer)
+        expect(check.latency_ms).to be >= 0
+      end
+    end
+
+    context "when df fails" do
+      before do
+        allow(Open3).to receive(:capture3).with("df", "-Pk", "/")
+          .and_return(["", "", instance_double(Process::Status, success?: false, exitstatus: 1)])
+      end
+
+      subject(:check) { described_class.new }
+
+      it "sets status to critical" do
+        check.call
+        expect(check.status).to eq("critical")
+      end
+
+      it "records the error message" do
+        check.call
+        expect(check.message).to match(/df command failed/)
+      end
+    end
+
+    context "with warn threshold" do
+      subject(:check) { described_class.new(warn_threshold: 10_737_418_240) }  # 10 GB
+
+      context "when free space is above warn threshold" do
+        let(:available_kb) { 20_000_000 }  # ~19 GB free
+
+        before do
+          allow(Open3).to receive(:capture3).with("df", "-Pk", "/")
+            .and_return([df_output(available_kb), "", instance_double(Process::Status, success?: true, exitstatus: 0)])
+        end
+
+        it "sets status to ok" do
+          check.call
+          expect(check.status).to eq("ok")
+        end
+      end
+
+      context "when free space is below warn threshold" do
+        let(:available_kb) { 5_000_000 }  # ~4.8 GB free, below 10 GB warn
+
+        before do
+          allow(Open3).to receive(:capture3).with("df", "-Pk", "/")
+            .and_return([df_output(available_kb), "", instance_double(Process::Status, success?: true, exitstatus: 0)])
+        end
+
+        it "sets status to degraded" do
+          check.call
+          expect(check.status).to eq("degraded")
+        end
+
+        it "includes free space and threshold in message" do
+          check.call
+          free = available_kb * 1024
+          expect(check.message).to eq("free disk space #{free} bytes below warn threshold 10737418240 bytes")
+        end
+      end
+    end
+
+    context "with critical threshold" do
+      subject(:check) { described_class.new(critical_threshold: 2_147_483_648) }  # 2 GB
+
+      context "when free space is above critical threshold" do
+        let(:available_kb) { 5_000_000 }  # ~4.8 GB free
+
+        before do
+          allow(Open3).to receive(:capture3).with("df", "-Pk", "/")
+            .and_return([df_output(available_kb), "", instance_double(Process::Status, success?: true, exitstatus: 0)])
+        end
+
+        it "sets status to ok" do
+          check.call
+          expect(check.status).to eq("ok")
+        end
+      end
+
+      context "when free space is below critical threshold" do
+        let(:available_kb) { 1_000_000 }  # ~976 MB free, below 2 GB critical
+
+        before do
+          allow(Open3).to receive(:capture3).with("df", "-Pk", "/")
+            .and_return([df_output(available_kb), "", instance_double(Process::Status, success?: true, exitstatus: 0)])
+        end
+
+        it "sets status to critical" do
+          check.call
+          expect(check.status).to eq("critical")
+        end
+
+        it "includes free space and threshold in message" do
+          check.call
+          free = available_kb * 1024
+          expect(check.message).to eq("free disk space #{free} bytes below critical threshold 2147483648 bytes")
+        end
+      end
+    end
+
+    context "with both warn and critical thresholds" do
+      let(:available_kb) { 500_000 }  # ~488 MB free
+
+      before do
+        allow(Open3).to receive(:capture3).with("df", "-Pk", "/")
+          .and_return([df_output(available_kb), "", instance_double(Process::Status, success?: true, exitstatus: 0)])
+      end
+
+      context "when free space is below critical threshold" do
+        subject(:check) { described_class.new(warn_threshold: 2_147_483_648, critical_threshold: 1_073_741_824) }
+
+        it "sets status to critical (not degraded)" do
+          check.call
+          expect(check.status).to eq("critical")
+        end
+      end
+    end
+
+    context "with a custom path" do
+      subject(:check) { described_class.new(path: "/var") }
+
+      before do
+        allow(Open3).to receive(:capture3).with("df", "-Pk", "/var")
+          .and_return([df_output(5_000_000), "", instance_double(Process::Status, success?: true, exitstatus: 0)])
+      end
+
+      it "passes the custom path to df" do
+        check.call
+        expect(Open3).to have_received(:capture3).with("df", "-Pk", "/var")
+      end
+
+      it "sets status to ok" do
+        check.call
+        expect(check.status).to eq("ok")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a built-in `:disk` check that uses `df -Pk` to measure free disk bytes — no external gem dependency
- Optional `config.disk_warn_threshold` (bytes) reports `degraded` when free space falls below the threshold
- Optional `config.disk_critical_threshold` (bytes) reports `critical` when free space falls below the threshold
- Optional `config.disk_path` selects which mount point to check (default: `/`)

Closes #9

## Test plan

- [ ] 13 new specs covering: ok, degraded, critical, both thresholds together, custom path, and `df` failure
- [ ] Full suite passes: 91 examples, 0 failures, 99.6% coverage
- [ ] RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)