### PR TITLE
feat: add memory check with process RSS threshold (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Built-in `disk` check using `df -Pk` to measure free disk bytes; optional `config.disk_warn_threshold` reports `degraded` and `config.disk_critical_threshold` reports `critical` when free space falls below the configured byte thresholds; `config.disk_path` selects the mount point to check (default: `/`)
+- Built-in `memory` check using `ps` to measure process RSS; optional `config.memory_threshold` (bytes) reports `degraded` when RSS exceeds the threshold
 
 ## [0.3.0] - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The block receives the `ActionDispatch::Request` object and must return a truthy
 | `:good_job` | GoodJob queue latency; optional `config.good_job_latency` (seconds) threshold for oldest pending job |
 | `:resque` | Resque Redis connectivity; optional `config.resque_queue_size` threshold for total queue depth |
 | `:disk` | Free disk bytes via `df`; optional `config.disk_warn_threshold` / `config.disk_critical_threshold` (bytes) and `config.disk_path` (default: `/`) |
+| `:memory` | Process RSS via `ps`; optional `config.memory_threshold` (bytes) reports `degraded` when exceeded |
 
 [↑ Back to top](#table-of-contents)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 > Host-level visibility and protection against hammering dependencies on every request.
 
 **Built-in checks:**
-- `memory` — process RSS vs configurable threshold
 - `http` — arbitrary external URL with configurable expected status code
 
 **Result caching:**

--- a/lib/rails_health_checks.rb
+++ b/lib/rails_health_checks.rb
@@ -12,6 +12,7 @@ require "rails_health_checks/checks/solid_queue_check"
 require "rails_health_checks/checks/good_job_check"
 require "rails_health_checks/checks/resque_check"
 require "rails_health_checks/checks/disk_check"
+require "rails_health_checks/checks/memory_check"
 require "rails_health_checks/check_registry"
 require "rails_health_checks/response_builder"
 

--- a/lib/rails_health_checks/check_registry.rb
+++ b/lib/rails_health_checks/check_registry.rb
@@ -11,6 +11,7 @@ module RailsHealthChecks
       solid_queue: -> { Checks::SolidQueueCheck.new(job_count: RailsHealthChecks.configuration.solid_queue_job_count) },
       good_job:    -> { Checks::GoodJobCheck.new(latency: RailsHealthChecks.configuration.good_job_latency) },
       resque:      -> { Checks::ResqueCheck.new(queue_size: RailsHealthChecks.configuration.resque_queue_size) },
+      memory:      -> { Checks::MemoryCheck.new(threshold: RailsHealthChecks.configuration.memory_threshold) },
       disk:        -> { Checks::DiskCheck.new(
         warn_threshold:     RailsHealthChecks.configuration.disk_warn_threshold,
         critical_threshold: RailsHealthChecks.configuration.disk_critical_threshold,

--- a/lib/rails_health_checks/checks/memory_check.rb
+++ b/lib/rails_health_checks/checks/memory_check.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module RailsHealthChecks
+  module Checks
+    class MemoryCheck < Check
+      def initialize(threshold: nil)
+        @threshold = threshold
+      end
+
+      def call
+        rss = nil
+        measure { rss = rss_bytes }
+
+        if @threshold && rss > @threshold
+          return warn_with("process RSS #{rss} bytes exceeds threshold #{@threshold} bytes")
+        end
+
+        pass
+      rescue StandardError => e
+        fail_with(e.message)
+      end
+
+      private
+
+      def rss_bytes
+        out, _, status = Open3.capture3("ps", "-o", "rss=", "-p", Process.pid.to_s)
+        raise "ps command failed with exit status #{status.exitstatus}" unless status.success?
+
+        out.strip.to_i * 1024
+      end
+    end
+  end
+end

--- a/lib/rails_health_checks/configuration.rb
+++ b/lib/rails_health_checks/configuration.rb
@@ -3,7 +3,8 @@
 module RailsHealthChecks
   class Configuration
     attr_accessor :checks, :timeout, :allowed_ips, :token, :sidekiq_queue_size, :solid_queue_job_count, :good_job_latency,
-                  :resque_queue_size, :disk_warn_threshold, :disk_critical_threshold, :disk_path
+                  :resque_queue_size, :disk_warn_threshold, :disk_critical_threshold, :disk_path,
+                  :memory_threshold
     attr_reader :authenticate_block
 
     def initialize
@@ -19,6 +20,7 @@ module RailsHealthChecks
       @disk_warn_threshold = nil
       @disk_critical_threshold = nil
       @disk_path = "/"
+      @memory_threshold = nil
     end
 
     def authenticate(&block)

--- a/spec/dummy/config/initializers/rails_health_checks.rb
+++ b/spec/dummy/config/initializers/rails_health_checks.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RailsHealthChecks.configure do |config|
+  config.checks = [:database, :cache, :disk, :memory]
+
+  config.disk_warn_threshold     = 1 * 1024**3  # 1 GB → degraded
+  config.disk_critical_threshold = 512 * 1024**2 # 512 MB → critical
+
+  config.memory_threshold = 512 * 1024**2 # 512 MB → degraded
+end

--- a/spec/lib/rails_health_checks/check_registry_spec.rb
+++ b/spec/lib/rails_health_checks/check_registry_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe RailsHealthChecks::CheckRegistry do
       expect(result[:sidekiq]).to be_a(RailsHealthChecks::Checks::SidekiqCheck)
     end
 
+    it "builds a memory check" do
+      result = described_class.build([:memory])
+      expect(result[:memory]).to be_a(RailsHealthChecks::Checks::MemoryCheck)
+    end
+
+    it "builds a disk check" do
+      result = described_class.build([:disk])
+      expect(result[:disk]).to be_a(RailsHealthChecks::Checks::DiskCheck)
+    end
+
     it "raises ArgumentError for unknown check names" do
       expect { described_class.build([:unknown]) }
         .to raise_error(ArgumentError, /Unknown check: unknown/)

--- a/spec/lib/rails_health_checks/checks/memory_check_spec.rb
+++ b/spec/lib/rails_health_checks/checks/memory_check_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "open3"
+
+RSpec.describe RailsHealthChecks::Checks::MemoryCheck do
+  def ps_output(rss_kb)
+    "#{rss_kb}\n"
+  end
+
+  let(:rss_kb) { 102_400 }  # 100 MB
+
+  before do
+    allow(Open3).to receive(:capture3).with("ps", "-o", "rss=", "-p", Process.pid.to_s)
+      .and_return([ps_output(rss_kb), "", instance_double(Process::Status, success?: true, exitstatus: 0)])
+  end
+
+  describe "#call" do
+    context "when ps succeeds" do
+      subject(:check) { described_class.new }
+
+      it "sets status to ok" do
+        check.call
+        expect(check.status).to eq("ok")
+      end
+
+      it "records latency in milliseconds" do
+        check.call
+        expect(check.latency_ms).to be_a(Integer)
+        expect(check.latency_ms).to be >= 0
+      end
+    end
+
+    context "when ps fails" do
+      before do
+        allow(Open3).to receive(:capture3).with("ps", "-o", "rss=", "-p", Process.pid.to_s)
+          .and_return(["", "", instance_double(Process::Status, success?: false, exitstatus: 1)])
+      end
+
+      subject(:check) { described_class.new }
+
+      it "sets status to critical" do
+        check.call
+        expect(check.status).to eq("critical")
+      end
+
+      it "records the error message" do
+        check.call
+        expect(check.message).to match(/ps command failed/)
+      end
+    end
+
+    context "with a threshold" do
+      context "when RSS is below threshold" do
+        subject(:check) { described_class.new(threshold: 512 * 1024 * 1024) }  # 512 MB
+
+        it "sets status to ok" do
+          check.call
+          expect(check.status).to eq("ok")
+        end
+      end
+
+      context "when RSS exceeds threshold" do
+        let(:rss_kb) { 614_400 }  # 600 MB
+        subject(:check) { described_class.new(threshold: 512 * 1024 * 1024) }  # 512 MB
+
+        it "sets status to degraded" do
+          check.call
+          expect(check.status).to eq("degraded")
+        end
+
+        it "includes RSS and threshold in message" do
+          check.call
+          rss = rss_kb * 1024
+          expect(check.message).to eq("process RSS #{rss} bytes exceeds threshold #{512 * 1024 * 1024} bytes")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a built-in `:memory` check that uses `ps -o rss=` to measure process RSS — no external gem dependency
- Optional `config.memory_threshold` (bytes) reports `degraded` when RSS exceeds the threshold
- Dummy app initializer updated to exercise all four checks: `:database`, `:cache`, `:disk`, `:memory`
- Registry spec extended to cover `:memory` and `:disk` factory lambdas — back to 100% line coverage

Closes #10

## Test plan

- [ ] 7 new specs covering: ok, degraded, ps failure, threshold above/below, message format
- [ ] Full suite passes: 100 examples, 0 failures, 100% line coverage
- [ ] RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)