### PR TITLE
feat: add custom check API via config.register (0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - Unreleased
+
+### Added
+- Custom check API: `config.register :name, MyCheck.new` registers a host-app check (subclass of `RailsHealthChecks::Check`) and appends it to the active checks list; the check is `dup`'d on each health request so state does not leak between calls
+
 ## [0.4.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Rails engine providing structured, pluggable health check endpoints for monito
 - [Configuration](#configuration)
 - [Authentication](#authentication)
 - [Built-in Checks](#built-in-checks)
+- [Custom Checks](#custom-checks)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -134,6 +135,29 @@ The block receives the `ActionDispatch::Request` object and must return a truthy
 | `:disk` | Free disk bytes via `df`; optional `config.disk_warn_threshold` / `config.disk_critical_threshold` (bytes) and `config.disk_path` (default: `/`) |
 | `:memory` | Process RSS via `ps`; optional `config.memory_threshold` (bytes) reports `degraded` when exceeded |
 | `:http` | HTTP GET to `config.http_url`; reports `critical` if response code differs from `config.http_expected_status` (default: `200`) or a network error occurs |
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Custom Checks
+
+Define a class inheriting from `RailsHealthChecks::Check` and register it in your initializer:
+
+```ruby
+class MyApiCheck < RailsHealthChecks::Check
+  def call
+    res = Net::HTTP.get_response(URI("https://api.example.com/status"))
+    res.code == "200" ? pass : fail_with("API returned #{res.code}")
+  end
+end
+
+RailsHealthChecks.configure do |config|
+  config.register :my_api, MyApiCheck.new
+end
+```
+
+`config.register` automatically adds the check to the active checks list. Use `pass`, `warn_with`, and `fail_with` (inherited from `Check`) to set status, and `measure { }` to record latency.
 
 [↑ Back to top](#table-of-contents)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,20 +8,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 
 > First-class extensibility for host applications.
 
-**Custom check API:**
-```ruby
-class MyApiCheck < RailsHealthChecks::Check
-  def call
-    res = Net::HTTP.get_response(URI('https://api.example.com/status'))
-    res.code == '200' ? pass : fail_with("API returned #{res.code}")
-  end
-end
-
-RailsHealthChecks.configure do |config|
-  config.register :external_api, MyApiCheck.new
-end
-```
-
 **Composite groups:**
 ```ruby
 config.group :external_services, [:external_api, :payment_gateway]

--- a/lib/rails_health_checks/check_registry.rb
+++ b/lib/rails_health_checks/check_registry.rb
@@ -24,11 +24,16 @@ module RailsHealthChecks
     }.freeze
 
     def self.build(check_names)
+      custom = RailsHealthChecks.configuration.custom_checks
       check_names.each_with_object({}) do |name, hash|
-        factory = BUILT_INS.fetch(name) do
-          raise ArgumentError, "Unknown check: #{name}. Available: #{BUILT_INS.keys.join(', ')}"
+        if BUILT_INS.key?(name)
+          hash[name] = BUILT_INS[name].call
+        elsif custom.key?(name)
+          hash[name] = custom[name].dup
+        else
+          available = (BUILT_INS.keys + custom.keys).join(", ")
+          raise ArgumentError, "Unknown check: #{name}. Available: #{available}"
         end
-        hash[name] = factory.call
       end
     end
 

--- a/lib/rails_health_checks/configuration.rb
+++ b/lib/rails_health_checks/configuration.rb
@@ -5,7 +5,7 @@ module RailsHealthChecks
     attr_accessor :checks, :timeout, :allowed_ips, :token, :sidekiq_queue_size, :solid_queue_job_count, :good_job_latency,
                   :resque_queue_size, :disk_warn_threshold, :disk_critical_threshold, :disk_path,
                   :memory_threshold, :http_url, :http_expected_status
-    attr_reader :authenticate_block
+    attr_reader :authenticate_block, :custom_checks
 
     def initialize
       @checks = [:database]
@@ -23,10 +23,16 @@ module RailsHealthChecks
       @memory_threshold = nil
       @http_url = nil
       @http_expected_status = 200
+      @custom_checks = {}
     end
 
     def authenticate(&block)
       @authenticate_block = block
+    end
+
+    def register(name, check)
+      @custom_checks[name] = check
+      @checks << name unless @checks.include?(name)
     end
   end
 end

--- a/spec/dummy/config/initializers/rails_health_checks.rb
+++ b/spec/dummy/config/initializers/rails_health_checks.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+class AppStatusCheck < RailsHealthChecks::Check
+  def call
+    measure { }
+    pass "app is running"
+  end
+end
+
 RailsHealthChecks.configure do |config|
   config.checks = [:database, :cache, :disk, :memory]
 
@@ -7,4 +14,6 @@ RailsHealthChecks.configure do |config|
   config.disk_critical_threshold = 512 * 1024**2 # 512 MB → critical
 
   config.memory_threshold = 512 * 1024**2 # 512 MB → degraded
+
+  config.register :app_status, AppStatusCheck.new
 end

--- a/spec/lib/rails_health_checks/check_registry_spec.rb
+++ b/spec/lib/rails_health_checks/check_registry_spec.rb
@@ -61,6 +61,40 @@ RSpec.describe RailsHealthChecks::CheckRegistry do
       expect(result[:disk]).to be_a(RailsHealthChecks::Checks::DiskCheck)
     end
 
+    context "with a custom registered check" do
+      let(:custom_check) do
+        Class.new(RailsHealthChecks::Check) do
+          def call = pass("custom ok")
+        end.new
+      end
+
+      before do
+        RailsHealthChecks.configuration.register(:my_service, custom_check)
+      end
+
+      after do
+        RailsHealthChecks.instance_variable_set(:@configuration, nil)
+      end
+
+      it "builds the custom check by name" do
+        result = described_class.build([:my_service])
+        expect(result[:my_service]).to be_a(RailsHealthChecks::Check)
+      end
+
+      it "returns a dup so state does not leak between builds" do
+        result1 = described_class.build([:my_service])
+        result2 = described_class.build([:my_service])
+        expect(result1[:my_service]).not_to be(result2[:my_service])
+      end
+
+      it "runs the custom check successfully" do
+        result = described_class.build([:my_service])
+        described_class.run(result, timeout: 5)
+        expect(result[:my_service].status).to eq("ok")
+        expect(result[:my_service].message).to eq("custom ok")
+      end
+    end
+
     it "raises ArgumentError for unknown check names" do
       expect { described_class.build([:unknown]) }
         .to raise_error(ArgumentError, /Unknown check: unknown/)

--- a/spec/lib/rails_health_checks_spec.rb
+++ b/spec/lib/rails_health_checks_spec.rb
@@ -16,5 +16,31 @@ RSpec.describe RailsHealthChecks do
       described_class.configure { |c| c.timeout = 10 }
       expect(described_class.configuration.timeout).to eq(10)
     end
+
+    describe "config.register" do
+      let(:custom_check) do
+        Class.new(RailsHealthChecks::Check) do
+          def call = pass("custom ok")
+        end.new
+      end
+
+      it "stores the check in custom_checks" do
+        described_class.configure { |c| c.register(:my_check, custom_check) }
+        expect(described_class.configuration.custom_checks[:my_check]).to eq(custom_check)
+      end
+
+      it "appends the name to config.checks" do
+        described_class.configure { |c| c.register(:my_check, custom_check) }
+        expect(described_class.configuration.checks).to include(:my_check)
+      end
+
+      it "does not duplicate the name in config.checks when called twice" do
+        described_class.configure do |c|
+          c.register(:my_check, custom_check)
+          c.register(:my_check, custom_check)
+        end
+        expect(described_class.configuration.checks.count(:my_check)).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `config.register :name, MyCheck.new` registers a host-app check (subclass of `RailsHealthChecks::Check`) and automatically appends it to the active checks list
- `CheckRegistry.build` falls back to custom checks after built-ins; raises `ArgumentError` listing both built-in and custom names for unknown checks
- Custom check instances are `dup`'d on each health request so state does not leak between calls
- Dummy app shows an `AppStatusCheck` example
- README updated with a Custom Checks section and usage example

Closes #13

## Test plan

- [ ] 6 new examples: `register` stores check, appends name, deduplicates; registry builds custom check, dups between builds, runs successfully
- [ ] Full suite: 116 examples, 0 failures, 100% line coverage
- [ ] RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)