### PR TITLE
feat: add per-check timeout override via config.register timeout: (0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Parallel check execution via `Concurrent::Future` — all checks now run concurrently, reducing total response time from the sum of check latencies to roughly the slowest single check; `concurrent-ruby` is a transitive Rails dependency and requires no additional gem
+- Per-check timeout: `config.register :slow_api, check, timeout: 10` overrides the global `config.timeout` for that specific check; checks without an explicit timeout continue to use the global value
 
 ## [0.5.0] - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,11 @@ RailsHealthChecks.configure do |config|
 end
 ```
 
-`config.register` automatically adds the check to the active checks list. Use `pass`, `warn_with`, and `fail_with` (inherited from `Check`) to set status, and `measure { }` to record latency.
+`config.register` automatically adds the check to the active checks list. Pass `timeout:` to override the global timeout for this check only:
+
+```ruby
+config.register :slow_api, MyApiCheck.new, timeout: 10
+``` Use `pass`, `warn_with`, and `fail_with` (inherited from `Check`) to set status, and `measure { }` to record latency.
 
 [↑ Back to top](#table-of-contents)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 
 > Production performance and integration with monitoring pipelines.
 
-- **Per-check timeout** — `config.register :slow_api, check, timeout: 10`
 - **ActiveSupport::Notifications** — publish `health_check.rails_health_checks` on each run; host apps can subscribe for custom alerting
 - **Prometheus endpoint** — `GET /health/metrics` returning Prometheus text exposition format
 

--- a/lib/rails_health_checks/check.rb
+++ b/lib/rails_health_checks/check.rb
@@ -2,6 +2,7 @@
 
 module RailsHealthChecks
   class Check
+    attr_accessor :timeout
     attr_reader :status, :message, :latency_ms
 
     def call

--- a/lib/rails_health_checks/check_registry.rb
+++ b/lib/rails_health_checks/check_registry.rb
@@ -39,9 +39,13 @@ module RailsHealthChecks
     end
 
     def self.run(checks, timeout:)
-      futures = checks.transform_values { |check| Concurrent::Future.execute { run_check(check, timeout: timeout) } }
+      futures = checks.transform_values do |check|
+        t = check.timeout || timeout
+        Concurrent::Future.execute { run_check(check, timeout: t) }
+      end
       checks.each_with_object({}) do |(name, check), results|
-        results[name] = futures[name].value(timeout + 1) || mark_critical(check, "timed out")
+        t = check.timeout || timeout
+        results[name] = futures[name].value(t + 1) || mark_critical(check, "timed out")
       end
     end
 

--- a/lib/rails_health_checks/configuration.rb
+++ b/lib/rails_health_checks/configuration.rb
@@ -48,7 +48,8 @@ module RailsHealthChecks
       @groups[name] = check_names
     end
 
-    def register(name, check)
+    def register(name, check, timeout: nil)
+      check.timeout = timeout
       @custom_checks[name] = check
       @checks << name unless @checks.include?(name)
     end

--- a/spec/lib/rails_health_checks/check_registry_spec.rb
+++ b/spec/lib/rails_health_checks/check_registry_spec.rb
@@ -125,6 +125,20 @@ RSpec.describe RailsHealthChecks::CheckRegistry do
       end
     end
 
+    context "when a check has a per-check timeout" do
+      let(:slow_check) do
+        Class.new(RailsHealthChecks::Check) do
+          def call = (sleep 10) && pass("done")
+        end.new.tap { |c| c.timeout = 1 }
+      end
+
+      it "uses the check's own timeout instead of the global one" do
+        results = described_class.run({ slow: slow_check }, timeout: 30)
+        expect(results[:slow].status).to eq("critical")
+        expect(results[:slow].message).to eq("timed out")
+      end
+    end
+
     context "with multiple checks running in parallel" do
       let(:slow_check_class) do
         Class.new(RailsHealthChecks::Check) do

--- a/spec/lib/rails_health_checks_spec.rb
+++ b/spec/lib/rails_health_checks_spec.rb
@@ -79,6 +79,16 @@ RSpec.describe RailsHealthChecks do
         expect(described_class.configuration.checks).to include(:my_check)
       end
 
+      it "sets a per-check timeout on the check object" do
+        described_class.configure { |c| c.register(:my_check, custom_check, timeout: 10) }
+        expect(described_class.configuration.custom_checks[:my_check].timeout).to eq(10)
+      end
+
+      it "leaves timeout nil when not specified" do
+        described_class.configure { |c| c.register(:my_check, custom_check) }
+        expect(described_class.configuration.custom_checks[:my_check].timeout).to be_nil
+      end
+
       it "does not duplicate the name in config.checks when called twice" do
         described_class.configure do |c|
           c.register(:my_check, custom_check)


### PR DESCRIPTION
## Summary

- `config.register :slow_api, check, timeout: 10` sets a per-check timeout on the check object (`Check#timeout`)
- `CheckRegistry.run` uses `check.timeout || global_timeout` for each future, so unset checks fall back to the global value
- The `value(t + 1)` collection buffer also respects the per-check timeout

Closes #17

## Test plan

- [ ] 2 config specs: timeout stored on check, nil when not specified
- [ ] 1 registry spec: per-check timeout fires instead of the (much longer) global timeout
- [ ] Full suite: 129 examples, 0 failures, 100% line coverage
- [ ] RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)