### PR TITLE
feat: add Prometheus metrics endpoint and refactor controllers (0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Prometheus metrics endpoint `GET /health/metrics` returning Prometheus text exposition format (`text/plain; version=0.0.4`); always returns HTTP 200; exposes `rails_health_check_status` (0=ok, 1=degraded, 2=critical) and `rails_health_check_latency_ms` gauges per check
 - Parallel check execution via `Concurrent::Future` — all checks now run concurrently, reducing total response time from the sum of check latencies to roughly the slowest single check; `concurrent-ruby` is a transitive Rails dependency and requires no additional gem
 - Per-check timeout: `config.register :slow_api, check, timeout: 10` overrides the global `config.timeout` for that specific check; checks without an explicit timeout continue to use the global value
 - ActiveSupport::Notifications: publishes `health_check.rails_health_checks` on every check run; payload includes `status` (overall) and `checks` (per-check status, message, latency_ms); wraps the full execution so subscribers receive accurate duration

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Rails engine providing structured, pluggable health check endpoints for monito
 - [Authentication](#authentication)
 - [Built-in Checks](#built-in-checks)
 - [Notifications](#notifications)
+- [Prometheus Metrics](#prometheus-metrics)
 - [Per-Environment Toggling](#per-environment-toggling)
 - [Check Groups](#check-groups)
 - [Custom Checks](#custom-checks)
@@ -54,8 +55,9 @@ mount RailsHealthChecks::Engine => "/health"
 |----------|--------|----------|
 | `GET /health` | JSON | Monitoring dashboards, detailed diagnostics |
 | `GET /health/live` | Plain text | Load balancer liveness probes |
+| `GET /health/metrics` | Prometheus text | Prometheus / OpenMetrics scraping |
 
-HTTP status is `200 OK` when all checks pass, `503 Service Unavailable` otherwise.
+HTTP status is `200 OK` when all checks pass, `503 Service Unavailable` otherwise (except `/metrics` which always returns `200`).
 
 ### JSON response shape
 
@@ -156,6 +158,26 @@ end
 ```
 
 The payload includes `status` (overall: `ok`/`degraded`/`critical`) and `checks` (per-check hash with `status`, `latency_ms`, and `message` when present). Duration is measured over the entire parallel check run.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Prometheus Metrics
+
+`GET /health/metrics` returns Prometheus text exposition format (`text/plain; version=0.0.4`). This endpoint always returns HTTP 200 — Prometheus convention is that scrape targets should always respond successfully, with check state encoded in metric values.
+
+```
+# HELP rails_health_check_status Health check status (0=ok, 1=degraded, 2=critical)
+# TYPE rails_health_check_status gauge
+rails_health_check_status{check="database"} 0
+rails_health_check_status{check="cache"} 0
+
+# HELP rails_health_check_latency_ms Health check latency in milliseconds
+# TYPE rails_health_check_latency_ms gauge
+rails_health_check_latency_ms{check="database"} 4
+rails_health_check_latency_ms{check="cache"} 2
+```
 
 [↑ Back to top](#table-of-contents)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,14 +4,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 
 ---
 
-## [0.6.0] — Async & Observability
-
-> Production performance and integration with monitoring pipelines.
-
-- **Prometheus endpoint** — `GET /health/metrics` returning Prometheus text exposition format
-
----
-
 ## [1.0.0] — Stable
 
 > Production-hardened, fully documented, and migration-friendly.

--- a/app/controllers/rails_health_checks/application_controller.rb
+++ b/app/controllers/rails_health_checks/application_controller.rb
@@ -4,5 +4,13 @@ module RailsHealthChecks
   class ApplicationController < ActionController::API
     include Authentication
     before_action :authenticate!
+
+    private
+
+    def run_checks(check_names)
+      config = RailsHealthChecks.configuration
+      checks = CheckRegistry.build(check_names)
+      CheckRegistry.run(checks, timeout: config.timeout)
+    end
   end
 end

--- a/app/controllers/rails_health_checks/groups_controller.rb
+++ b/app/controllers/rails_health_checks/groups_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  class GroupsController < ApplicationController
+    def show
+      group_name = params[:id].to_sym
+      check_names = RailsHealthChecks.configuration.groups[group_name]
+      return render json: { error: "Group '#{group_name}' not found" }, status: :not_found unless check_names
+
+      builder = ResponseBuilder.new(run_checks(check_names))
+      render json: builder.to_json, status: builder.http_status
+    end
+  end
+end

--- a/app/controllers/rails_health_checks/health_controller.rb
+++ b/app/controllers/rails_health_checks/health_controller.rb
@@ -6,38 +6,5 @@ module RailsHealthChecks
       builder = ResponseBuilder.new(run_checks(RailsHealthChecks.configuration.checks))
       render json: builder.to_json, status: builder.http_status
     end
-
-    def live
-      builder = ResponseBuilder.new(run_checks(RailsHealthChecks.configuration.checks))
-      if builder.overall_status == "ok"
-        render plain: "OK", status: :ok
-      else
-        render plain: "Service Unavailable", status: :service_unavailable
-      end
-    end
-
-    def metrics
-      results = run_checks(RailsHealthChecks.configuration.checks)
-      render plain: PrometheusFormatter.new(results).to_text,
-             content_type: "text/plain; version=0.0.4",
-             status: :ok
-    end
-
-    def group
-      group_name = params[:group].to_sym
-      check_names = RailsHealthChecks.configuration.groups[group_name]
-      return render json: { error: "Group '#{group_name}' not found" }, status: :not_found unless check_names
-
-      builder = ResponseBuilder.new(run_checks(check_names))
-      render json: builder.to_json, status: builder.http_status
-    end
-
-    private
-
-    def run_checks(check_names)
-      config = RailsHealthChecks.configuration
-      checks = CheckRegistry.build(check_names)
-      CheckRegistry.run(checks, timeout: config.timeout)
-    end
   end
 end

--- a/app/controllers/rails_health_checks/health_controller.rb
+++ b/app/controllers/rails_health_checks/health_controller.rb
@@ -16,6 +16,13 @@ module RailsHealthChecks
       end
     end
 
+    def metrics
+      results = run_checks(RailsHealthChecks.configuration.checks)
+      render plain: PrometheusFormatter.new(results).to_text,
+             content_type: "text/plain; version=0.0.4",
+             status: :ok
+    end
+
     def group
       group_name = params[:group].to_sym
       check_names = RailsHealthChecks.configuration.groups[group_name]

--- a/app/controllers/rails_health_checks/live_controller.rb
+++ b/app/controllers/rails_health_checks/live_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  class LiveController < ApplicationController
+    def show
+      builder = ResponseBuilder.new(run_checks(RailsHealthChecks.configuration.checks))
+      if builder.overall_status == "ok"
+        render plain: "OK", status: :ok
+      else
+        render plain: "Service Unavailable", status: :service_unavailable
+      end
+    end
+  end
+end

--- a/app/controllers/rails_health_checks/metrics_controller.rb
+++ b/app/controllers/rails_health_checks/metrics_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  class MetricsController < ApplicationController
+    def show
+      results = run_checks(RailsHealthChecks.configuration.checks)
+      render plain: PrometheusFormatter.new(results).to_text,
+             content_type: "text/plain; version=0.0.4",
+             status: :ok
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RailsHealthChecks::Engine.routes.draw do
-  get "/",       to: "health#show",  as: :health
-  get "/live",   to: "health#live",  as: :health_live
-  get "/:group", to: "health#group", as: :health_group
+  get "/",        to: "health#show",    as: :health
+  get "/live",    to: "health#live",    as: :health_live
+  get "/metrics", to: "health#metrics", as: :health_metrics
+  get "/:group",  to: "health#group",   as: :health_group
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RailsHealthChecks::Engine.routes.draw do
-  get "/",        to: "health#show",    as: :health
-  get "/live",    to: "health#live",    as: :health_live
-  get "/metrics", to: "health#metrics", as: :health_metrics
-  get "/:group",  to: "health#group",   as: :health_group
+  get "/",        to: "health#show",   as: :health
+  get "/live",    to: "live#show",     as: :health_live
+  get "/metrics", to: "metrics#show",  as: :health_metrics
+  get "/:id",     to: "groups#show",   as: :health_group
 end

--- a/lib/rails_health_checks.rb
+++ b/lib/rails_health_checks.rb
@@ -16,6 +16,7 @@ require "rails_health_checks/checks/memory_check"
 require "rails_health_checks/checks/http_check"
 require "rails_health_checks/check_registry"
 require "rails_health_checks/response_builder"
+require "rails_health_checks/prometheus_formatter"
 
 module RailsHealthChecks
   class << self

--- a/lib/rails_health_checks/prometheus_formatter.rb
+++ b/lib/rails_health_checks/prometheus_formatter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  class PrometheusFormatter
+    STATUS_CODES = { "ok" => 0, "degraded" => 1, "critical" => 2 }.freeze
+
+    def initialize(results)
+      @results = results
+    end
+
+    def to_text
+      lines = []
+
+      lines << "# HELP rails_health_check_status Health check status (0=ok, 1=degraded, 2=critical)"
+      lines << "# TYPE rails_health_check_status gauge"
+      @results.each { |name, check| lines << "rails_health_check_status{check=\"#{name}\"} #{STATUS_CODES[check.status]}" }
+
+      lines << ""
+      lines << "# HELP rails_health_check_latency_ms Health check latency in milliseconds"
+      lines << "# TYPE rails_health_check_latency_ms gauge"
+      @results.each do |name, check|
+        lines << "rails_health_check_latency_ms{check=\"#{name}\"} #{check.latency_ms}" if check.latency_ms
+      end
+
+      lines.join("\n") + "\n"
+    end
+  end
+end

--- a/spec/lib/rails_health_checks/prometheus_formatter_spec.rb
+++ b/spec/lib/rails_health_checks/prometheus_formatter_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RailsHealthChecks::PrometheusFormatter do
+  def build_check(status, latency_ms: nil)
+    check = RailsHealthChecks::Check.new
+    check.instance_variable_set(:@status, status)
+    check.instance_variable_set(:@latency_ms, latency_ms)
+    check
+  end
+
+  let(:results) do
+    {
+      database: build_check("ok", latency_ms: 3),
+      cache:    build_check("degraded", latency_ms: 12),
+      worker:   build_check("critical")
+    }
+  end
+
+  subject(:output) { described_class.new(results).to_text }
+
+  it "includes the status HELP and TYPE headers" do
+    expect(output).to include("# HELP rails_health_check_status")
+    expect(output).to include("# TYPE rails_health_check_status gauge")
+  end
+
+  it "maps ok status to 0" do
+    expect(output).to include('rails_health_check_status{check="database"} 0')
+  end
+
+  it "maps degraded status to 1" do
+    expect(output).to include('rails_health_check_status{check="cache"} 1')
+  end
+
+  it "maps critical status to 2" do
+    expect(output).to include('rails_health_check_status{check="worker"} 2')
+  end
+
+  it "includes the latency HELP and TYPE headers" do
+    expect(output).to include("# HELP rails_health_check_latency_ms")
+    expect(output).to include("# TYPE rails_health_check_latency_ms gauge")
+  end
+
+  it "emits latency lines for checks that have latency" do
+    expect(output).to include('rails_health_check_latency_ms{check="database"} 3')
+    expect(output).to include('rails_health_check_latency_ms{check="cache"} 12')
+  end
+
+  it "omits latency lines for checks with no latency" do
+    expect(output).not_to include('rails_health_check_latency_ms{check="worker"}')
+  end
+
+  it "ends with a newline" do
+    expect(output).to end_with("\n")
+  end
+end

--- a/spec/requests/rails_health_checks/health_spec.rb
+++ b/spec/requests/rails_health_checks/health_spec.rb
@@ -77,6 +77,34 @@ RSpec.describe 'Health endpoints', type: :request do
     end
   end
 
+  describe 'GET /health/metrics' do
+    context 'when all checks pass' do
+      it 'returns 200 with Prometheus content type' do
+        get '/health/metrics'
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include('text/plain')
+        expect(response.content_type).to include('version=0.0.4')
+      end
+
+      it 'includes status gauge lines' do
+        get '/health/metrics'
+
+        expect(response.body).to include('# TYPE rails_health_check_status gauge')
+        expect(response.body).to include('rails_health_check_status{check="database"}')
+      end
+
+      it 'always returns 200 even when a check is critical' do
+        allow(ActiveRecord::Base.connection).to receive(:execute).and_raise(StandardError, 'db down')
+
+        get '/health/metrics'
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('rails_health_check_status{check="database"} 2')
+      end
+    end
+  end
+
   describe 'GET /health/live' do
     context 'when all checks pass' do
       it 'returns 200 with OK text' do


### PR DESCRIPTION
## Summary

- Adds `GET /health/metrics` returning Prometheus text exposition format (`text/plain; version=0.0.4`); always returns HTTP 200 per Prometheus convention; exposes `rails_health_check_status` (0=ok, 1=degraded, 2=critical) and `rails_health_check_latency_ms` gauges per check
- Refactors single `HealthController` with custom actions into four focused controllers (`HealthController`, `LiveController`, `MetricsController`, `GroupsController`), each with only a `#show` action; moves shared `run_checks` to `ApplicationController`

## Test plan

- [ ] All 142 examples pass, 0 failures
- [ ] 100% line coverage maintained
- [ ] RuboCop clean
- [ ] `GET /health/metrics` returns Prometheus text with correct content type
- [ ] `/metrics` always returns 200 even when a check is critical
- [ ] All existing endpoints (`/health`, `/health/live`, `/health/:id`) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)