### PR TITLE
feat: result caching, HEAD support, HTTP headers, boot validation (0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Result caching: `config.cache_duration = N` (seconds) caches check results in memory, avoiding re-running expensive checks on every request; disabled by default; keyed per check set so group endpoints cache independently; thread-safe
+- HEAD request support on `GET /health` and `GET /health/live` for load balancer compatibility
+- HTTP check custom headers: `config.http_headers = { "Authorization" => "Bearer ..." }` allows probing authenticated endpoints
+- Boot-time configuration validation: raises `RailsHealthChecks::ConfigurationError` at app startup for unknown check names, `:http` check without `http_url`, and groups referencing missing checks
+
 ## [0.6.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ mount RailsHealthChecks::Engine => "/health"
 | `GET /health/live` | Plain text | Load balancer liveness probes |
 | `GET /health/metrics` | Prometheus text | Prometheus / OpenMetrics scraping |
 
+`/health` and `/health/live` also respond to `HEAD` requests (useful for lightweight load balancer probes).
+
 HTTP status is `200 OK` when all checks pass, `503 Service Unavailable` otherwise (except `/metrics` which always returns `200`).
 
 ### JSON response shape
@@ -82,10 +84,13 @@ Status values: `ok` | `degraded` | `critical`. Overall status is `critical` if a
 ```ruby
 # config/initializers/rails_health_checks.rb
 RailsHealthChecks.configure do |config|
-  config.checks  = [:database, :cache]  # checks to run (default: [:database])
-  config.timeout = 5            # global timeout per check in seconds (default: 5)
+  config.checks         = [:database, :cache]  # checks to run (default: [:database])
+  config.timeout        = 5                    # global timeout per check in seconds (default: 5)
+  config.cache_duration = 10                   # cache results for N seconds (default: nil, disabled)
 end
 ```
+
+Configuration is validated at boot time. An unknown check name or a missing `http_url` for the `:http` check raises `RailsHealthChecks::ConfigurationError` on startup rather than silently failing on the first request.
 
 [↑ Back to top](#table-of-contents)
 
@@ -139,7 +144,7 @@ The block receives the `ActionDispatch::Request` object and must return a truthy
 | `:resque` | Resque Redis connectivity; optional `config.resque_queue_size` threshold for total queue depth |
 | `:disk` | Free disk bytes via `df`; optional `config.disk_warn_threshold` / `config.disk_critical_threshold` (bytes) and `config.disk_path` (default: `/`) |
 | `:memory` | Process RSS via `ps`; optional `config.memory_threshold` (bytes) reports `degraded` when exceeded |
-| `:http` | HTTP GET to `config.http_url`; reports `critical` if response code differs from `config.http_expected_status` (default: `200`) or a network error occurs |
+| `:http` | HTTP GET to `config.http_url`; reports `critical` if response code differs from `config.http_expected_status` (default: `200`) or a network error occurs; optional `config.http_headers` hash sends custom request headers (e.g. `{ "Authorization" => "Bearer ..." }`) |
 
 [↑ Back to top](#table-of-contents)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,17 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 
 ---
 
+## [0.7.0] — Production Polish
+
+> Small features that close real production pain points before 1.0.0.
+
+- **Result caching** — `config.cache_duration = N` (seconds) avoids re-running expensive checks on every request; default off; keyed per check set so groups cache independently
+- **HEAD request support** — verify and document HEAD on `GET /health` and `GET /health/live` for load balancer compatibility
+- **HTTP check custom headers** — `config.http_headers = { "Authorization" => "Bearer ..." }` enables probing authenticated endpoints
+- **Boot-time config validation** — raises `ConfigurationError` at startup for unknown check names, `:http` with no `http_url`, and groups referencing missing checks
+
+---
+
 ## [1.0.0] — Stable
 
 > Production-hardened, fully documented, and migration-friendly.

--- a/app/controllers/rails_health_checks/application_controller.rb
+++ b/app/controllers/rails_health_checks/application_controller.rb
@@ -9,6 +9,18 @@ module RailsHealthChecks
 
     def run_checks(check_names)
       config = RailsHealthChecks.configuration
+
+      if config.cache_duration
+        cache_key = check_names.map(&:to_s).sort.join(",")
+        RailsHealthChecks.result_cache.fetch(cache_key, ttl: config.cache_duration) do
+          build_and_run(check_names, config)
+        end
+      else
+        build_and_run(check_names, config)
+      end
+    end
+
+    def build_and_run(check_names, config)
       checks = CheckRegistry.build(check_names)
       CheckRegistry.run(checks, timeout: config.timeout)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RailsHealthChecks::Engine.routes.draw do
-  get "/",        to: "health#show",   as: :health
-  get "/live",    to: "live#show",     as: :health_live
+  match "/",      to: "health#show",   as: :health,      via: [:get, :head]
+  match "/live",  to: "live#show",     as: :health_live, via: [:get, :head]
   get "/metrics", to: "metrics#show",  as: :health_metrics
   get "/:id",     to: "groups#show",   as: :health_group
 end

--- a/lib/rails_health_checks.rb
+++ b/lib/rails_health_checks.rb
@@ -17,6 +17,7 @@ require "rails_health_checks/checks/http_check"
 require "rails_health_checks/check_registry"
 require "rails_health_checks/response_builder"
 require "rails_health_checks/prometheus_formatter"
+require "rails_health_checks/result_cache"
 
 module RailsHealthChecks
   class << self
@@ -26,6 +27,10 @@ module RailsHealthChecks
 
     def configuration
       @configuration ||= Configuration.new
+    end
+
+    def result_cache
+      @result_cache ||= ResultCache.new
     end
   end
 end

--- a/lib/rails_health_checks/check_registry.rb
+++ b/lib/rails_health_checks/check_registry.rb
@@ -15,7 +15,8 @@ module RailsHealthChecks
       memory:      -> { Checks::MemoryCheck.new(threshold: RailsHealthChecks.configuration.memory_threshold) },
       http:        -> { Checks::HttpCheck.new(
         url:             RailsHealthChecks.configuration.http_url,
-        expected_status: RailsHealthChecks.configuration.http_expected_status
+        expected_status: RailsHealthChecks.configuration.http_expected_status,
+        headers:         RailsHealthChecks.configuration.http_headers
       ) },
       disk:        -> { Checks::DiskCheck.new(
         warn_threshold:     RailsHealthChecks.configuration.disk_warn_threshold,

--- a/lib/rails_health_checks/checks/http_check.rb
+++ b/lib/rails_health_checks/checks/http_check.rb
@@ -6,14 +6,18 @@ require "uri"
 module RailsHealthChecks
   module Checks
     class HttpCheck < Check
-      def initialize(url:, expected_status: 200)
+      def initialize(url:, expected_status: 200, headers: {})
         @url = url
         @expected_status = expected_status
+        @headers = headers
       end
 
       def call
         measure do
-          response = Net::HTTP.get_response(URI.parse(@url))
+          uri = URI.parse(@url)
+          request = Net::HTTP::Get.new(uri)
+          @headers.each { |name, value| request[name] = value }
+          response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") { |http| http.request(request) }
           code = response.code.to_i
           return fail_with("HTTP GET #{@url} returned #{code}, expected #{@expected_status}") if code != @expected_status
         end

--- a/lib/rails_health_checks/configuration.rb
+++ b/lib/rails_health_checks/configuration.rb
@@ -1,16 +1,22 @@
 # frozen_string_literal: true
 
 module RailsHealthChecks
+  class ConfigurationError < StandardError; end
+
   class Configuration
+    BUILT_IN_NAMES = %i[database cache sidekiq solid_queue good_job resque disk memory http].freeze
+
     attr_writer :checks
-    attr_accessor :timeout, :allowed_ips, :token, :sidekiq_queue_size, :solid_queue_job_count, :good_job_latency,
+    attr_accessor :timeout, :cache_duration, :allowed_ips, :token,
+                  :sidekiq_queue_size, :solid_queue_job_count, :good_job_latency,
                   :resque_queue_size, :disk_warn_threshold, :disk_critical_threshold, :disk_path,
-                  :memory_threshold, :http_url, :http_expected_status
+                  :memory_threshold, :http_url, :http_expected_status, :http_headers
     attr_reader :authenticate_block, :custom_checks, :groups
 
     def initialize
       @checks = [:database]
       @timeout = 5
+      @cache_duration = nil
       @allowed_ips = nil
       @token = nil
       @authenticate_block = nil
@@ -24,6 +30,7 @@ module RailsHealthChecks
       @memory_threshold = nil
       @http_url = nil
       @http_expected_status = 200
+      @http_headers = {}
       @custom_checks = {}
       @groups = {}
       @disabled_checks = {}
@@ -52,6 +59,19 @@ module RailsHealthChecks
       check.timeout = timeout
       @custom_checks[name] = check
       @checks << name unless @checks.include?(name)
+    end
+
+    def validate!
+      all_checks = @checks + @groups.values.flatten
+      all_checks.uniq.each do |name|
+        next if BUILT_IN_NAMES.include?(name) || @custom_checks.key?(name)
+
+        raise ConfigurationError, "Unknown check :#{name}. Built-ins: #{BUILT_IN_NAMES.join(', ')}"
+      end
+
+      if @checks.include?(:http) && @http_url.nil?
+        raise ConfigurationError, "config.checks includes :http but config.http_url is not set"
+      end
     end
   end
 end

--- a/lib/rails_health_checks/engine.rb
+++ b/lib/rails_health_checks/engine.rb
@@ -4,5 +4,9 @@ module RailsHealthChecks
   class Engine < ::Rails::Engine
     isolate_namespace RailsHealthChecks
     config.generators.api_only = true
+
+    config.after_initialize do
+      RailsHealthChecks.configuration.validate!
+    end
   end
 end

--- a/lib/rails_health_checks/result_cache.rb
+++ b/lib/rails_health_checks/result_cache.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RailsHealthChecks
+  class ResultCache
+    def initialize
+      @store = {}
+      @mutex = Mutex.new
+    end
+
+    def fetch(key, ttl:)
+      @mutex.synchronize do
+        entry = @store[key]
+        return entry[:results] if entry && (Process.clock_gettime(Process::CLOCK_MONOTONIC) - entry[:at]) < ttl
+
+        results = yield
+        @store[key] = { results: results, at: Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+        results
+      end
+    end
+
+    def clear
+      @mutex.synchronize { @store.clear }
+    end
+  end
+end

--- a/spec/lib/rails_health_checks/checks/http_check_spec.rb
+++ b/spec/lib/rails_health_checks/checks/http_check_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe RailsHealthChecks::Checks::HttpCheck do
 
   def stub_response(code)
     response = instance_double(Net::HTTPResponse, code: code.to_s)
-    allow(Net::HTTP).to receive(:get_response).with(URI.parse(url)).and_return(response)
+    http = instance_double(Net::HTTP)
+    allow(Net::HTTP).to receive(:start).and_yield(http)
+    allow(http).to receive(:request).and_return(response)
+  end
+
+  def stub_network_error(error_class, message)
+    allow(Net::HTTP).to receive(:start).and_raise(error_class, message)
   end
 
   describe "#call" do
@@ -72,10 +78,28 @@ RSpec.describe RailsHealthChecks::Checks::HttpCheck do
       end
     end
 
-    context "when a network error occurs" do
-      before do
-        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError, "getaddrinfo: nodename nor servname provided")
+    context "with custom request headers" do
+      subject(:check) { described_class.new(url: url, headers: { "Authorization" => "Bearer secret", "X-Custom" => "value" }) }
+
+      it "sends the headers with the request" do
+        response = instance_double(Net::HTTPResponse, code: "200")
+        http = instance_double(Net::HTTP)
+        request_spy = instance_spy(Net::HTTP::Get)
+
+        allow(Net::HTTP).to receive(:start).and_yield(http)
+        allow(Net::HTTP::Get).to receive(:new).and_return(request_spy)
+        allow(http).to receive(:request).with(request_spy).and_return(response)
+
+        check.call
+
+        expect(request_spy).to have_received(:[]=).with("Authorization", "Bearer secret")
+        expect(request_spy).to have_received(:[]=).with("X-Custom", "value")
+        expect(check.status).to eq("ok")
       end
+    end
+
+    context "when a network error occurs" do
+      before { stub_network_error(SocketError, "getaddrinfo: nodename nor servname provided") }
 
       subject(:check) { described_class.new(url: url) }
 

--- a/spec/lib/rails_health_checks/configuration_spec.rb
+++ b/spec/lib/rails_health_checks/configuration_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RailsHealthChecks::Configuration do
+  subject(:config) { described_class.new }
+
+  describe "#validate!" do
+    it "does not raise for the default configuration" do
+      expect { config.validate! }.not_to raise_error
+    end
+
+    it "does not raise when all checks are known built-ins" do
+      config.checks = [:database, :cache, :disk]
+      expect { config.validate! }.not_to raise_error
+    end
+
+    it "raises ConfigurationError for an unknown check name" do
+      config.checks = [:database, :nonexistent]
+      expect { config.validate! }.to raise_error(RailsHealthChecks::ConfigurationError, /nonexistent/)
+    end
+
+    it "raises ConfigurationError when :http is included but http_url is not set" do
+      config.checks = [:http]
+      config.http_url = nil
+      expect { config.validate! }.to raise_error(RailsHealthChecks::ConfigurationError, /http_url/)
+    end
+
+    it "does not raise when :http is included and http_url is set" do
+      config.checks = [:http]
+      config.http_url = "http://example.com/status"
+      expect { config.validate! }.not_to raise_error
+    end
+
+    it "raises ConfigurationError when a group references an unknown check" do
+      config.group(:infra, [:database, :missing_check])
+      expect { config.validate! }.to raise_error(RailsHealthChecks::ConfigurationError, /missing_check/)
+    end
+
+    it "does not raise when a group references a custom registered check" do
+      custom = Class.new(RailsHealthChecks::Check) { def call = pass("ok") }.new
+      config.register(:my_svc, custom)
+      config.group(:app, [:database, :my_svc])
+      expect { config.validate! }.not_to raise_error
+    end
+  end
+
+  describe "defaults" do
+    it "defaults cache_duration to nil (disabled)" do
+      expect(config.cache_duration).to be_nil
+    end
+
+    it "defaults http_headers to an empty hash" do
+      expect(config.http_headers).to eq({})
+    end
+  end
+end

--- a/spec/lib/rails_health_checks/result_cache_spec.rb
+++ b/spec/lib/rails_health_checks/result_cache_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RailsHealthChecks::ResultCache do
+  subject(:cache) { described_class.new }
+
+  describe "#fetch" do
+    it "calls the block on the first access and returns its value" do
+      result = cache.fetch("key", ttl: 60) { :fresh }
+      expect(result).to eq(:fresh)
+    end
+
+    it "returns the cached value without calling the block again within TTL" do
+      calls = 0
+      cache.fetch("key", ttl: 60) { calls += 1; :value }
+      result = cache.fetch("key", ttl: 60) { calls += 1; :value }
+
+      expect(calls).to eq(1)
+      expect(result).to eq(:value)
+    end
+
+    it "re-executes the block after TTL expires" do
+      calls = 0
+      cache.fetch("key", ttl: 0.01) { calls += 1 }
+      sleep 0.02
+      cache.fetch("key", ttl: 0.01) { calls += 1 }
+
+      expect(calls).to eq(2)
+    end
+
+    it "caches different keys independently" do
+      cache.fetch("a", ttl: 60) { :a }
+      cache.fetch("b", ttl: 60) { :b }
+
+      expect(cache.fetch("a", ttl: 60) { :miss }).to eq(:a)
+      expect(cache.fetch("b", ttl: 60) { :miss }).to eq(:b)
+    end
+  end
+
+  describe "#clear" do
+    it "removes all cached entries so the next fetch re-executes the block" do
+      cache.fetch("key", ttl: 60) { :original }
+      cache.clear
+      result = cache.fetch("key", ttl: 60) { :refreshed }
+
+      expect(result).to eq(:refreshed)
+    end
+  end
+end

--- a/spec/requests/rails_health_checks/health_spec.rb
+++ b/spec/requests/rails_health_checks/health_spec.rb
@@ -105,6 +105,71 @@ RSpec.describe 'Health endpoints', type: :request do
     end
   end
 
+  describe 'HEAD /health' do
+    it 'returns 200 with no body' do
+      head '/health'
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to be_empty
+    end
+
+    context 'when the database check fails' do
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:execute).and_raise(StandardError, 'connection refused')
+      end
+
+      it 'returns 503 with no body' do
+        head '/health'
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response.body).to be_empty
+      end
+    end
+  end
+
+  describe 'HEAD /health/live' do
+    it 'returns 200 with no body' do
+      head '/health/live'
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to be_empty
+    end
+  end
+
+  describe 'result caching' do
+    after { RailsHealthChecks.instance_variable_set(:@result_cache, nil) }
+
+    context 'when cache_duration is set' do
+      before do
+        RailsHealthChecks.configure { |c| c.cache_duration = 60 }
+      end
+
+      after { RailsHealthChecks.instance_variable_set(:@configuration, nil) }
+
+      it 'returns the same result without re-running checks on a second request' do
+        call_count = 0
+        allow(ActiveRecord::Base.connection).to receive(:execute) { call_count += 1 }
+
+        get '/health'
+        get '/health'
+
+        expect(call_count).to eq(1)
+      end
+    end
+
+    context 'when cache_duration is nil (default)' do
+      it 're-runs checks on every request' do
+        call_count = 0
+        allow(ActiveRecord::Base.connection).to receive(:execute) { call_count += 1 }
+
+        get '/health'
+        get '/health'
+
+        expect(call_count).to eq(2)
+      end
+    end
+  end
+
   describe 'GET /health/live' do
     context 'when all checks pass' do
       it 'returns 200 with OK text' do


### PR DESCRIPTION
## Summary

- **Result caching** (`#44`) — `config.cache_duration = N` caches check results in memory for N seconds; thread-safe `Mutex`-backed store keyed per check set; disabled by default
- **HEAD support** (`#45`) — `/health` and `/health/live` now respond to HEAD requests for lightweight load balancer probes
- **HTTP check custom headers** (`#46`) — `config.http_headers = { "Authorization" => "Bearer ..." }` enables probing authenticated endpoints
- **Boot-time config validation** (`#47`) — raises `ConfigurationError` at app startup for unknown check names, `:http` without `http_url`, and groups referencing missing checks

Closes #44, #45, #46, #47

## Test plan

- [ ] 162 examples, 0 failures
- [ ] 100% line coverage
- [ ] RuboCop clean
- [ ] HEAD /health and HEAD /health/live return 200 with empty body
- [ ] Caching: second request does not re-run checks within TTL
- [ ] HTTP check sends custom headers
- [ ] ConfigurationError raised at boot for bad config

🤖 Generated with [Claude Code](https://claude.com/claude-code)