### PR TITLE
docs: complete 1.0.0 documentation sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Built-in `:smtp` check that verifies mail server connectivity via `Net::SMTP` (stdlib, no extra gems); automatically reads `ActionMailer::Base.smtp_settings` when no explicit config is provided; optional `config.smtp_address` and `config.smtp_port` override the defaults (fallback: `localhost:25`)
-
-### Added
 - Built-in `:redis` check that pings a Redis server directly, independent of any job queue gem; requires the `redis` gem in the host app; optional `config.redis_url` overrides the `REDIS_URL` env var (default: `redis://localhost:6379/0`)
-
-### Added
 - `rails generate rails_health_checks:initializer` — generates a fully commented `config/initializers/rails_health_checks.rb` in the host app with all available configuration options documented inline
+- Complete configuration reference table in README covering all config options with types, defaults, and descriptions
+- Custom check authoring guide in README: full `Check` API reference (`pass`, `warn_with`, `fail_with`, `measure`), state contract, and testing patterns
+- `MIGRATING_FROM_OKCOMPUTER.md`: complete migration guide from OkComputer with check name mappings, configuration translation, custom check migration, and response format differences
 
 ## [0.7.0] - 2026-06-09
 

--- a/MIGRATING_FROM_OKCOMPUTER.md
+++ b/MIGRATING_FROM_OKCOMPUTER.md
@@ -1,0 +1,247 @@
+# Migrating from OkComputer
+
+This guide helps you migrate from [OkComputer](https://github.com/sportngin/okcomputer) to `rails_health_checks`.
+
+## Table of Contents
+
+- [Why Migrate](#why-migrate)
+- [Installation Differences](#installation-differences)
+- [Endpoint Mapping](#endpoint-mapping)
+- [Check Name Mapping](#check-name-mapping)
+- [Configuration Mapping](#configuration-mapping)
+- [Custom Check Migration](#custom-check-migration)
+- [Authentication Migration](#authentication-migration)
+- [Response Format Differences](#response-format-differences)
+
+---
+
+## Why Migrate
+
+| Feature | OkComputer | rails_health_checks |
+|---------|------------|---------------------|
+| Engine type | Mountable engine | Mountable engine |
+| Response format | JSON / text | JSON / text / Prometheus |
+| Check parallelism | Sequential | Parallel (`Concurrent::Future`) |
+| Per-check latency | No | Yes (`latency_ms`) |
+| Result caching | No | Yes (`config.cache_duration`) |
+| `HEAD` support | No | Yes |
+| Boot-time validation | No | Yes (raises on unknown check names) |
+| Custom checks | `OkComputer::Check` subclass | `RailsHealthChecks::Check` subclass |
+| ActiveSupport::Notifications | No | Yes |
+
+---
+
+## Installation Differences
+
+**OkComputer:**
+
+```ruby
+# Gemfile
+gem "okcomputer"
+
+# config/routes.rb — auto-mounted, no explicit mount needed
+```
+
+**rails_health_checks:**
+
+```ruby
+# Gemfile
+gem "rails_health_checks"
+
+# config/routes.rb
+mount RailsHealthChecks::Engine => "/health"
+```
+
+rails_health_checks requires an explicit `mount` so you control the path.
+
+---
+
+## Endpoint Mapping
+
+| OkComputer endpoint | rails_health_checks equivalent |
+|--------------------|-------------------------------|
+| `GET /okcomputer` | `GET /health` |
+| `GET /okcomputer/all` | `GET /health` |
+| `GET /okcomputer/:check` | Not supported; use [check groups](README.md#check-groups) |
+| (no Prometheus endpoint) | `GET /health/metrics` |
+| (no liveness endpoint) | `GET /health/live` |
+
+---
+
+## Check Name Mapping
+
+| OkComputer check class | rails_health_checks symbol | Notes |
+|------------------------|---------------------------|-------|
+| `OkComputer::ActiveRecordCheck` | `:database` | Runs `SELECT 1` on all configured connections |
+| `OkComputer::CacheCheck` | `:cache` | Read/write probe via `Rails.cache` |
+| `OkComputer::RedisCheck` | `:redis` | Requires `gem 'redis'`; set `config.redis_url` or `REDIS_URL` env |
+| `OkComputer::SidekiqLatencyCheck` | `:sidekiq` | Set `config.sidekiq_queue_size` for depth threshold |
+| `OkComputer::ResqueCheck` | `:resque` | Set `config.resque_queue_size` for depth threshold |
+| `OkComputer::HttpCheck` | `:http` | Set `config.http_url` (required) |
+| `OkComputer::MongoidCheck` | — | Not available; use a [custom check](README.md#custom-checks) |
+| `OkComputer::ElasticsearchCheck` | — | Not available; use a [custom check](README.md#custom-checks) |
+| `OkComputer::DelayedJobCheck` | — | Not available; use a [custom check](README.md#custom-checks) |
+| (no equivalent) | `:smtp` | New: SMTP connectivity check |
+| (no equivalent) | `:disk` | New: free disk space check |
+| (no equivalent) | `:memory` | New: process RSS check |
+| (no equivalent) | `:solid_queue` | New: SolidQueue check |
+| (no equivalent) | `:good_job` | New: GoodJob check |
+
+---
+
+## Configuration Mapping
+
+OkComputer registered checks inline in an initializer by calling class methods. rails_health_checks uses a single `configure` block with symbols.
+
+**OkComputer style:**
+
+```ruby
+# config/initializers/okcomputer.rb
+OkComputer.mount_at = "health"
+OkComputer::Registry.register "database", OkComputer::ActiveRecordCheck.new
+OkComputer::Registry.register "cache",    OkComputer::CacheCheck.new
+OkComputer::Registry.register "redis",    OkComputer::RedisCheck.new(url: ENV["REDIS_URL"])
+OkComputer::Registry.register "sidekiq",  OkComputer::SidekiqLatencyCheck.new("default", 100)
+OkComputer::Registry.deregister "default"
+OkComputer.make_optional %w[cache redis]
+```
+
+**rails_health_checks equivalent:**
+
+```ruby
+# config/initializers/rails_health_checks.rb
+RailsHealthChecks.configure do |config|
+  config.checks          = [:database, :cache, :redis, :sidekiq]
+  config.redis_url       = ENV["REDIS_URL"]
+  config.sidekiq_queue_size = 100
+end
+```
+
+There is no concept of optional/required checks per endpoint — the overall HTTP status is `503` if any check is `critical`.
+
+---
+
+## Custom Check Migration
+
+**OkComputer custom check:**
+
+```ruby
+class MyServiceCheck < OkComputer::Check
+  def check
+    response = Net::HTTP.get_response(URI("https://my-service.example.com/status"))
+    if response.code.to_i == 200
+      mark_message "my-service OK"
+    else
+      mark_failure
+      mark_message "my-service returned #{response.code}"
+    end
+  end
+end
+
+OkComputer::Registry.register "my_service", MyServiceCheck.new
+```
+
+**rails_health_checks equivalent:**
+
+```ruby
+class MyServiceCheck < RailsHealthChecks::Check
+  def call
+    measure do
+      response = Net::HTTP.get_response(URI("https://my-service.example.com/status"))
+      if response.code.to_i == 200
+        pass("my-service OK")
+      else
+        fail_with("my-service returned #{response.code}")
+      end
+    end
+  rescue StandardError => e
+    fail_with(e.message)
+  end
+end
+
+RailsHealthChecks.configure do |config|
+  config.register :my_service, MyServiceCheck.new
+end
+```
+
+Key differences:
+
+| OkComputer | rails_health_checks |
+|------------|---------------------|
+| `mark_message` | `pass(message)` |
+| `mark_failure` | `fail_with(message)` |
+| (no degraded state) | `warn_with(message)` for `degraded` |
+| `mark_message` in `check` | `measure { }` block records `latency_ms` automatically |
+| Register with `Registry.register` | `config.register :name, check_instance` |
+
+---
+
+## Authentication Migration
+
+**OkComputer:**
+
+```ruby
+OkComputer.require_authentication("username", "password")
+OkComputer.make_optional %w[all]  # or restrict specific checks
+```
+
+**rails_health_checks:**
+
+```ruby
+RailsHealthChecks.configure do |config|
+  # Bearer token
+  config.token = ENV["HEALTH_TOKEN"]
+
+  # IP allowlist
+  config.allowed_ips = ["127.0.0.1", "10.0.0.0/8"]
+
+  # Custom block
+  config.authenticate { |request| request.headers["X-Internal"] == "true" }
+end
+```
+
+rails_health_checks does not support HTTP Basic Auth natively. If you need it, use the `authenticate` block:
+
+```ruby
+config.authenticate do |request|
+  credentials = ActionController::HttpAuthentication::Basic.decode_credentials(request)
+  credentials == "username:password"
+end
+```
+
+---
+
+## Response Format Differences
+
+OkComputer returns plain text by default; JSON on request. rails_health_checks always returns JSON from `GET /health`.
+
+**OkComputer JSON (`GET /okcomputer.json`):**
+
+```json
+{
+  "default": {
+    "message": "Database connected",
+    "failure": false
+  }
+}
+```
+
+**rails_health_checks JSON (`GET /health`):**
+
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-06-08T20:00:00Z",
+  "checks": {
+    "database": { "status": "ok", "latency_ms": 4 }
+  }
+}
+```
+
+Status values map as follows:
+
+| OkComputer `failure` | rails_health_checks `status` |
+|---------------------|------------------------------|
+| `false` | `"ok"` |
+| `true` | `"critical"` |
+| (no equivalent) | `"degraded"` |

--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ Mount the engine in `config/routes.rb`:
 mount RailsHealthChecks::Engine => "/health"
 ```
 
-Generate a commented initializer with all available options:
-
-```bash
-rails generate rails_health_checks:initializer
-```
-
 [↑ Back to top](#table-of-contents)
 
 ---
@@ -94,12 +88,117 @@ Status values: `ok` | `degraded` | `critical`. Overall status is `critical` if a
 
 ## Configuration
 
+Run the initializer generator to create `config/initializers/rails_health_checks.rb` with every option documented as a commented example:
+
+```bash
+rails generate rails_health_checks:initializer
+```
+
+The generated file (shown below with all options) uses the block-style `configure` API. Every setting has a sensible default — uncomment only what you need:
+
 ```ruby
-# config/initializers/rails_health_checks.rb
+# frozen_string_literal: true
+
 RailsHealthChecks.configure do |config|
-  config.checks         = [:database, :cache, :redis]
-  config.timeout        = 5
-  config.cache_duration = 10
+  # Checks to run (default: [:database])
+  # Available built-ins: :database, :cache, :redis, :smtp, :sidekiq, :solid_queue,
+  #                      :good_job, :resque, :disk, :memory, :http
+  config.checks = [:database]
+
+  # Global timeout per check in seconds (default: 5)
+  config.timeout = 5
+
+  # Cache check results for N seconds to avoid re-running on every request (default: nil, disabled)
+  # config.cache_duration = 10
+
+  # ---------------------------------------------------------------------------
+  # Authentication — all strategies are mutually exclusive; default is public
+  # ---------------------------------------------------------------------------
+
+  # Bearer token: requests must include Authorization: Bearer <token>
+  # config.token = ENV["HEALTH_TOKEN"]
+
+  # IP allowlist: exact IPs or CIDR ranges
+  # config.allowed_ips = ["127.0.0.1", "10.0.0.0/8"]
+
+  # Custom block: return truthy to allow the request
+  # config.authenticate { |request| request.headers["X-Internal"] == "true" }
+
+  # ---------------------------------------------------------------------------
+  # Per-environment toggling
+  # ---------------------------------------------------------------------------
+  # config.disable :disk,   in: :test
+  # config.disable :memory, in: [:test, :development]
+
+  # ---------------------------------------------------------------------------
+  # Check groups — expose subsets at GET /health/:group
+  # ---------------------------------------------------------------------------
+  # config.group :system,  [:disk, :memory]
+  # config.group :workers, [:sidekiq, :good_job]
+
+  # ---------------------------------------------------------------------------
+  # Redis check (requires :redis in config.checks and the redis gem)
+  # ---------------------------------------------------------------------------
+  # config.redis_url = ENV["REDIS_URL"]         # default: redis://localhost:6379/0
+
+  # ---------------------------------------------------------------------------
+  # SMTP check (requires :smtp in config.checks)
+  # Reads ActionMailer::Base.smtp_settings automatically if not set here.
+  # ---------------------------------------------------------------------------
+  # config.smtp_address = "smtp.example.com"  # default: ActionMailer config or localhost
+  # config.smtp_port    = 587                 # default: ActionMailer config or 25
+
+  # ---------------------------------------------------------------------------
+  # Disk check (requires :disk in config.checks)
+  # ---------------------------------------------------------------------------
+  # config.disk_path               = "/"             # mount point (default: "/")
+  # config.disk_warn_threshold     = 2 * 1024**3     # bytes free → degraded
+  # config.disk_critical_threshold = 512 * 1024**2   # bytes free → critical
+
+  # ---------------------------------------------------------------------------
+  # Memory check (requires :memory in config.checks)
+  # ---------------------------------------------------------------------------
+  # config.memory_threshold = 512 * 1024**2          # RSS bytes → degraded
+
+  # ---------------------------------------------------------------------------
+  # HTTP check (requires :http in config.checks)
+  # ---------------------------------------------------------------------------
+  # config.http_url             = "https://api.example.com/status"
+  # config.http_expected_status = 200                # expected response code (default: 200)
+  # config.http_headers         = { "Authorization" => "Bearer #{ENV['API_TOKEN']}" }
+
+  # ---------------------------------------------------------------------------
+  # Sidekiq check (requires :sidekiq in config.checks)
+  # ---------------------------------------------------------------------------
+  # config.sidekiq_queue_size = 1000                 # total depth → degraded
+
+  # ---------------------------------------------------------------------------
+  # Solid Queue check (requires :solid_queue in config.checks)
+  # ---------------------------------------------------------------------------
+  # config.solid_queue_job_count = 500               # pending jobs → degraded
+
+  # ---------------------------------------------------------------------------
+  # GoodJob check (requires :good_job in config.checks)
+  # ---------------------------------------------------------------------------
+  # config.good_job_latency = 300                    # seconds oldest job waiting → degraded
+
+  # ---------------------------------------------------------------------------
+  # Resque check (requires :resque in config.checks)
+  # ---------------------------------------------------------------------------
+  # config.resque_queue_size = 1000                  # total depth → degraded
+
+  # ---------------------------------------------------------------------------
+  # Custom checks
+  # ---------------------------------------------------------------------------
+  # class MyApiCheck < RailsHealthChecks::Check
+  #   def call
+  #     res = Net::HTTP.get_response(URI("https://api.example.com/status"))
+  #     res.code == "200" ? pass : fail_with("API returned #{res.code}")
+  #   end
+  # end
+  #
+  # config.register :my_api, MyApiCheck.new
+  # config.register :slow_api, MyApiCheck.new, timeout: 10  # per-check timeout override
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,18 @@ A Rails engine providing structured, pluggable health check endpoints for monito
 - [Installation](#installation)
 - [Endpoints](#endpoints)
 - [Configuration](#configuration)
+  - [Configuration Reference](#configuration-reference)
 - [Authentication](#authentication)
 - [Built-in Checks](#built-in-checks)
 - [Notifications](#notifications)
 - [Prometheus Metrics](#prometheus-metrics)
+- [Result Caching](#result-caching)
 - [Per-Environment Toggling](#per-environment-toggling)
 - [Check Groups](#check-groups)
 - [Custom Checks](#custom-checks)
+  - [Check API](#check-api)
+  - [Testing Custom Checks](#testing-custom-checks)
+- [Migrating from OkComputer](#migrating-from-okcomputer)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -62,6 +67,7 @@ rails generate rails_health_checks:initializer
 | `GET /health` | JSON | Monitoring dashboards, detailed diagnostics |
 | `GET /health/live` | Plain text | Load balancer liveness probes |
 | `GET /health/metrics` | Prometheus text | Prometheus / OpenMetrics scraping |
+| `GET /health/:group` | JSON | Scoped check group (e.g. `/health/workers`) |
 
 `/health` and `/health/live` also respond to `HEAD` requests (useful for lightweight load balancer probes).
 
@@ -74,12 +80,13 @@ HTTP status is `200 OK` when all checks pass, `503 Service Unavailable` otherwis
   "status": "ok",
   "timestamp": "2026-06-08T20:00:00Z",
   "checks": {
-    "database": { "status": "ok", "latency_ms": 4 }
+    "database": { "status": "ok", "latency_ms": 4 },
+    "cache":    { "status": "ok", "latency_ms": 1 }
   }
 }
 ```
 
-Status values: `ok` | `degraded` | `critical`. Overall status is `critical` if any check is `critical`, `degraded` if any is `degraded`.
+Status values: `ok` | `degraded` | `critical`. Overall status is `critical` if any check is `critical`, `degraded` if any is `degraded`, `ok` otherwise.
 
 [↑ Back to top](#table-of-contents)
 
@@ -90,13 +97,37 @@ Status values: `ok` | `degraded` | `critical`. Overall status is `critical` if a
 ```ruby
 # config/initializers/rails_health_checks.rb
 RailsHealthChecks.configure do |config|
-  config.checks         = [:database, :cache]  # checks to run (default: [:database])
-  config.timeout        = 5                    # global timeout per check in seconds (default: 5)
-  config.cache_duration = 10                   # cache results for N seconds (default: nil, disabled)
+  config.checks         = [:database, :cache, :redis]
+  config.timeout        = 5
+  config.cache_duration = 10
 end
 ```
 
-Configuration is validated at boot time. An unknown check name or a missing `http_url` for the `:http` check raises `RailsHealthChecks::ConfigurationError` on startup rather than silently failing on the first request.
+Configuration is validated at boot time. An unknown check name, a missing `http_url` for the `:http` check, or a group referencing an undefined check raises `RailsHealthChecks::ConfigurationError` on startup rather than silently failing on the first request.
+
+### Configuration Reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `checks` | `Array` | `[:database]` | Built-in or custom check names to run |
+| `timeout` | `Integer` | `5` | Global per-check timeout in seconds |
+| `cache_duration` | `Integer\|nil` | `nil` | Cache results for N seconds; `nil` disables caching |
+| `token` | `String\|nil` | `nil` | Bearer token for authentication |
+| `allowed_ips` | `Array\|nil` | `nil` | IP allowlist; accepts exact IPs and CIDR ranges |
+| `redis_url` | `String\|nil` | `nil` | Redis URL for `:redis` check; falls back to `REDIS_URL` env var then `redis://localhost:6379/0` |
+| `smtp_address` | `String\|nil` | `nil` | SMTP host for `:smtp` check; falls back to `ActionMailer` config then `localhost` |
+| `smtp_port` | `Integer\|nil` | `nil` | SMTP port for `:smtp` check; falls back to `ActionMailer` config then `25` |
+| `sidekiq_queue_size` | `Integer\|nil` | `nil` | Total Sidekiq queue depth that triggers `degraded` |
+| `solid_queue_job_count` | `Integer\|nil` | `nil` | Pending SolidQueue jobs that trigger `degraded` |
+| `good_job_latency` | `Integer\|nil` | `nil` | Oldest pending GoodJob age (seconds) that triggers `degraded` |
+| `resque_queue_size` | `Integer\|nil` | `nil` | Total Resque queue depth that triggers `degraded` |
+| `disk_path` | `String` | `"/"` | Mount point for `:disk` check |
+| `disk_warn_threshold` | `Integer\|nil` | `nil` | Free bytes below which `:disk` reports `degraded` |
+| `disk_critical_threshold` | `Integer\|nil` | `nil` | Free bytes below which `:disk` reports `critical` |
+| `memory_threshold` | `Integer\|nil` | `nil` | Process RSS bytes above which `:memory` reports `degraded` |
+| `http_url` | `String\|nil` | `nil` | Target URL for `:http` check (**required** when `:http` is active) |
+| `http_expected_status` | `Integer` | `200` | Expected HTTP response code for `:http` check |
+| `http_headers` | `Hash` | `{}` | Request headers sent by `:http` check |
 
 [↑ Back to top](#table-of-contents)
 
@@ -140,19 +171,21 @@ The block receives the `ActionDispatch::Request` object and must return a truthy
 
 ## Built-in Checks
 
-| Check | Description |
-|-------|-------------|
-| `:database` | ActiveRecord `SELECT 1` against the primary connection, includes latency |
-| `:cache` | `Rails.cache` read/write probe; works with Redis, Memcached, or in-process store |
-| `:redis` | Direct Redis ping via the `redis` gem; optional `config.redis_url` overrides the `REDIS_URL` env var (default: `redis://localhost:6379/0`) |
-| `:smtp` | SMTP server connectivity via `Net::SMTP` (no extra gems); reads `ActionMailer::Base.smtp_settings` automatically; optional `config.smtp_address` and `config.smtp_port` (fallback: `localhost:25`) |
-| `:sidekiq` | Sidekiq Redis connectivity; optional `config.sidekiq_queue_size` threshold for queue depth |
-| `:solid_queue` | Solid Queue DB connectivity; optional `config.solid_queue_job_count` threshold for pending jobs |
-| `:good_job` | GoodJob queue latency; optional `config.good_job_latency` (seconds) threshold for oldest pending job |
-| `:resque` | Resque Redis connectivity; optional `config.resque_queue_size` threshold for total queue depth |
-| `:disk` | Free disk bytes via `df`; optional `config.disk_warn_threshold` / `config.disk_critical_threshold` (bytes) and `config.disk_path` (default: `/`) |
-| `:memory` | Process RSS via `ps`; optional `config.memory_threshold` (bytes) reports `degraded` when exceeded |
-| `:http` | HTTP GET to `config.http_url`; reports `critical` if response code differs from `config.http_expected_status` (default: `200`) or a network error occurs; optional `config.http_headers` hash sends custom request headers (e.g. `{ "Authorization" => "Bearer ..." }`) |
+| Check | Requires | Description |
+|-------|----------|-------------|
+| `:database` | — | ActiveRecord `SELECT 1` against the primary connection |
+| `:cache` | — | `Rails.cache` read/write probe; works with any cache store |
+| `:redis` | `redis` gem | Direct Redis `PING`; `config.redis_url` or `REDIS_URL` env var |
+| `:smtp` | — | SMTP connectivity via `Net::SMTP`; reads `ActionMailer` config automatically |
+| `:sidekiq` | `sidekiq` gem | Sidekiq Redis connectivity; optional `config.sidekiq_queue_size` depth threshold |
+| `:solid_queue` | `solid_queue` gem | SolidQueue DB connectivity; optional `config.solid_queue_job_count` threshold |
+| `:good_job` | `good_job` gem | GoodJob queue latency; optional `config.good_job_latency` (seconds) threshold |
+| `:resque` | `resque` gem | Resque Redis connectivity; optional `config.resque_queue_size` depth threshold |
+| `:disk` | — | Free disk space via `df`; `config.disk_warn_threshold` / `config.disk_critical_threshold` (bytes) |
+| `:memory` | — | Process RSS via `ps`; optional `config.memory_threshold` (bytes) reports `degraded` when exceeded |
+| `:http` | — | HTTP GET to `config.http_url`; `config.http_expected_status` and `config.http_headers` |
+
+All checks run in parallel. Each check times out independently using `config.timeout` (default: 5s) or a per-check override set via `config.register`.
 
 [↑ Back to top](#table-of-contents)
 
@@ -170,7 +203,14 @@ ActiveSupport::Notifications.subscribe("health_check.rails_health_checks") do |*
 end
 ```
 
-The payload includes `status` (overall: `ok`/`degraded`/`critical`) and `checks` (per-check hash with `status`, `latency_ms`, and `message` when present). Duration is measured over the entire parallel check run.
+The payload includes:
+
+| Key | Value |
+|-----|-------|
+| `status` | Overall status: `"ok"`, `"degraded"`, or `"critical"` |
+| `checks` | Hash of `{ check_name => { status:, latency_ms:, message: } }` |
+
+`duration` on the event covers the entire parallel check run, not individual checks.
 
 [↑ Back to top](#table-of-contents)
 
@@ -178,7 +218,7 @@ The payload includes `status` (overall: `ok`/`degraded`/`critical`) and `checks`
 
 ## Prometheus Metrics
 
-`GET /health/metrics` returns Prometheus text exposition format (`text/plain; version=0.0.4`). This endpoint always returns HTTP 200 — Prometheus convention is that scrape targets should always respond successfully, with check state encoded in metric values.
+`GET /health/metrics` returns Prometheus text exposition format (`text/plain; version=0.0.4`). This endpoint always returns HTTP 200 per Prometheus scraping convention — check state is encoded in metric values.
 
 ```
 # HELP rails_health_check_status Health check status (0=ok, 1=degraded, 2=critical)
@@ -191,6 +231,24 @@ rails_health_check_status{check="cache"} 0
 rails_health_check_latency_ms{check="database"} 4
 rails_health_check_latency_ms{check="cache"} 2
 ```
+
+Latency lines are omitted for checks that do not call `measure { }`.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Result Caching
+
+By default every request re-runs all checks. Set `cache_duration` to serve cached results for N seconds, reducing load on the database, Redis, and other dependencies:
+
+```ruby
+RailsHealthChecks.configure do |config|
+  config.cache_duration = 10  # seconds
+end
+```
+
+The cache is keyed per check set — `GET /health` and `GET /health/workers` cache independently. The cache is in-process (not shared across dynos/containers), so each instance maintains its own result window.
 
 [↑ Back to top](#table-of-contents)
 
@@ -225,12 +283,12 @@ RailsHealthChecks.configure do |config|
 end
 ```
 
-| Endpoint | Description |
-|----------|-------------|
-| `GET /health/system` | Runs only `:disk` and `:memory`, same JSON shape as `GET /health` |
-| `GET /health/workers` | Runs only `:sidekiq` and `:good_job` |
+| Endpoint | Runs |
+|----------|------|
+| `GET /health/system` | `:disk`, `:memory` |
+| `GET /health/workers` | `:sidekiq`, `:good_job` |
 
-Unknown group names return `404 Not Found`.
+The response shape is identical to `GET /health`. Unknown group names return `404 Not Found`.
 
 [↑ Back to top](#table-of-contents)
 
@@ -238,26 +296,103 @@ Unknown group names return `404 Not Found`.
 
 ## Custom Checks
 
-Define a class inheriting from `RailsHealthChecks::Check` and register it in your initializer:
+### Authoring
+
+Define a class inheriting from `RailsHealthChecks::Check`, implement `call`, and register it:
 
 ```ruby
-class MyApiCheck < RailsHealthChecks::Check
+class PaymentGatewayCheck < RailsHealthChecks::Check
   def call
-    res = Net::HTTP.get_response(URI("https://api.example.com/status"))
-    res.code == "200" ? pass : fail_with("API returned #{res.code}")
+    measure do
+      response = Net::HTTP.get_response(URI("https://api.stripe.com/v1/charges"))
+      case response.code.to_i
+      when 200, 401  # 401 = auth error, but gateway is reachable
+        pass
+      when 429
+        warn_with("rate limited (429)")
+      else
+        fail_with("unexpected status #{response.code}")
+      end
+    end
+  rescue StandardError => e
+    fail_with(e.message)
   end
 end
 
 RailsHealthChecks.configure do |config|
-  config.register :my_api, MyApiCheck.new
+  config.register :payment_gateway, PaymentGatewayCheck.new
+  config.register :slow_gateway,    PaymentGatewayCheck.new, timeout: 15
 end
 ```
 
-`config.register` automatically adds the check to the active checks list. Pass `timeout:` to override the global timeout for this check only:
+`config.register` appends the check to the active list automatically.
+
+### Check API
+
+| Method | Status set | Use when |
+|--------|-----------|----------|
+| `pass(message = nil)` | `ok` | Check passed; optional message |
+| `warn_with(message)` | `degraded` | Check is functional but degraded |
+| `fail_with(message)` | `critical` | Check failed; service is impaired |
+| `measure { }` | — | Wraps a block and records `latency_ms` |
+
+**State contract:** call exactly one of `pass`, `warn_with`, or `fail_with` per `call` invocation. The check instance is `dup`'d before each run, so instance variables set during one request do not bleed into the next.
+
+### Testing Custom Checks
+
+Call the check directly in a unit test — no request stack needed:
 
 ```ruby
-config.register :slow_api, MyApiCheck.new, timeout: 10
-``` Use `pass`, `warn_with`, and `fail_with` (inherited from `Check`) to set status, and `measure { }` to record latency.
+RSpec.describe PaymentGatewayCheck do
+  subject(:check) { described_class.new }
+
+  context "when the gateway is reachable" do
+    before do
+      stub_request(:get, "https://api.stripe.com/v1/charges")
+        .to_return(status: 200)
+    end
+
+    it "passes" do
+      check.call
+      expect(check.status).to eq("ok")
+    end
+  end
+
+  context "when the gateway is rate-limited" do
+    before do
+      stub_request(:get, "https://api.stripe.com/v1/charges")
+        .to_return(status: 429)
+    end
+
+    it "warns" do
+      check.call
+      expect(check.status).to eq("degraded")
+      expect(check.message).to include("rate limited")
+    end
+  end
+end
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Migrating from OkComputer
+
+See [MIGRATING_FROM_OKCOMPUTER.md](MIGRATING_FROM_OKCOMPUTER.md) for a full mapping of check names, configuration keys, and endpoint differences.
+
+Quick reference:
+
+| OkComputer | rails_health_checks |
+|------------|---------------------|
+| `OkComputer::ActiveRecordCheck` | `:database` |
+| `OkComputer::CacheCheck` | `:cache` |
+| `OkComputer::RedisCheck` | `:redis` |
+| `OkComputer::SidekiqLatencyCheck` | `:sidekiq` + `config.sidekiq_queue_size` |
+| `OkComputer::HttpCheck` | `:http` + `config.http_url` |
+| `OkComputer::CustomCheck` subclass | Subclass `RailsHealthChecks::Check` |
+| `GET /okcomputer` | `GET /health` |
+| `GET /okcomputer/all` | `GET /health` |
 
 [↑ Back to top](#table-of-contents)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,8 +8,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 
 > Production-hardened, fully documented, and migration-friendly.
 
-- Complete README: configuration reference, all built-in checks, custom check authoring guide
-- Migration guide from `okcomputer` (check name mappings)
 - Rails 8.1+ compatibility locked in CI matrix
 - Performance benchmarks
 - CHANGELOG complete


### PR DESCRIPTION
## Summary

- Rewrites README with full configuration reference table (all config options with types, defaults, and descriptions), inline initializer reference (matching the `rails_audit_log` pattern), custom check authoring guide with full `Check` API docs and testing patterns, and per-section back-to-top links
- Adds `MIGRATING_FROM_OKCOMPUTER.md` with complete endpoint, check name, configuration, custom check, and authentication mapping tables
- Fixes duplicate `### Added` sections in CHANGELOG and adds documentation entries under `[Unreleased]`
- Removes shipped documentation items from ROADMAP 1.0.0 section

## Test plan

- [ ] CI passes (lint + spec)
- [ ] README renders correctly on GitHub
- [ ] `MIGRATING_FROM_OKCOMPUTER.md` link in README resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)