### PR TITLE
feat: expand CI matrix to Rails 8.0+; relax gemspec to >= 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,21 @@ jobs:
       - run: bundle exec bundle-audit check
 
   test:
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         ruby: ["3.3", "3.4", "4.0"]
+        gemfile:
+          - Gemfile
+          - gemfiles/rails_8_0.gemfile
+        exclude:
+          - ruby: "4.0"
+            gemfile: gemfiles/rails_8_0.gemfile
     env:
       RAILS_ENV: test
+      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
 
     steps:
       - uses: actions/checkout@v6
@@ -73,7 +80,7 @@ jobs:
       - run: bundle exec rspec
 
       - name: Upload coverage to Codecov
-        if: matrix.ruby == '4.0'
+        if: matrix.ruby == '4.0' && matrix.gemfile == 'Gemfile'
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Complete configuration reference table in README covering all config options with types, defaults, and descriptions
 - Custom check authoring guide in README: full `Check` API reference (`pass`, `warn_with`, `fail_with`, `measure`), state contract, and testing patterns
 - `MIGRATING_FROM_OKCOMPUTER.md`: complete migration guide from OkComputer with check name mappings, configuration translation, custom check migration, and response format differences
+- Rails version CI matrix: test job now runs against `Gemfile` (latest Rails) and `gemfiles/rails_8_0.gemfile` (minimum supported Rails) across Ruby 3.3 and 3.4; Ruby 4.0 tested against latest Rails only
+- Relaxed Rails dependency from `>= 8.1.3` to `>= 8.0` to support all currently-maintained Rails versions
 
 ## [0.7.0] - 2026-06-09
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rails_health_checks (0.7.0)
-      rails (>= 8.1.3)
+      rails (>= 8.0)
 
 GEM
   remote: https://rubygems.org/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,6 @@ Rails 7.1 added a basic `/up` endpoint via `Rails::HealthController`, but it onl
 
 > Production-hardened, fully documented, and migration-friendly.
 
-- Rails 8.1+ compatibility locked in CI matrix
+- Rails 8.0+ compatibility locked in CI matrix
 - Performance benchmarks
 - CHANGELOG complete

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rails", "~> 8.0.0"
+
+gemspec path: ".."
+
+gem "puma"
+gem "sqlite3"
+
+gem "bundler-audit",          require: false
+gem "factory_bot_rails"
+gem "rspec-rails"
+gem "rubocop-rails"
+gem "rubocop-rails-omakase",  require: false
+gem "simplecov",              require: false
+gem "simplecov-json",         require: false

--- a/rails_health_checks.gemspec
+++ b/rails_health_checks.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
     Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   end
 
-  spec.add_dependency 'rails', '>= 8.1.3'
+  spec.add_dependency 'rails', '>= 8.0'
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -7,7 +7,7 @@ require 'rails_health_checks'
 
 module Dummy
   class Application < Rails::Application
-    config.load_defaults 8.1
+    config.load_defaults 8.0
     config.eager_load = false
     config.cache_store = :memory_store
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,5 +10,5 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 0) do
+ActiveRecord::Schema[8.0].define(version: 0) do
 end


### PR DESCRIPTION
## Summary

- Adds `gemfiles/rails_8_0.gemfile` pinned to `~> 8.0.0` for minimum-version testing
- Expands test job matrix to run Ruby 3.3/3.4 against both `Gemfile` (latest Rails) and `rails_8_0.gemfile`; Ruby 4.0 tested against latest Rails only
- Relaxes gemspec Rails dependency from `>= 8.1.3` to `>= 8.0`, covering all currently-maintained Rails versions (8.0 and 8.1+; 7.x is EOL)
- Drops dummy app `config.load_defaults` from `8.1` to `8.0` so the suite runs cleanly against both versions

## Test plan

- [ ] CI passes for all matrix combinations (Ruby 3.3/Gemfile, Ruby 3.3/rails_8_0, Ruby 3.4/Gemfile, Ruby 3.4/rails_8_0, Ruby 4.0/Gemfile)
- [ ] Coverage upload still fires on Ruby 4.0 / Gemfile only

🤖 Generated with [Claude Code](https://claude.com/claude-code)