### PR TITLE
feat: add Rails 7.1 and 7.2 support, clean up dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,15 @@ jobs:
         gemfile:
           - Gemfile
           - gemfiles/rails_8_0.gemfile
+          - gemfiles/rails_7_2.gemfile
+          - gemfiles/rails_7_1.gemfile
         exclude:
           - ruby: "4.0"
             gemfile: gemfiles/rails_8_0.gemfile
+          - ruby: "4.0"
+            gemfile: gemfiles/rails_7_2.gemfile
+          - ruby: "4.0"
+            gemfile: gemfiles/rails_7_1.gemfile
     env:
       RAILS_ENV: test
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `RailsHealthChecks::Rack::App` — a mountable Rack app that exposes the same four endpoints (`GET/HEAD /`, `GET/HEAD /live`, `GET /metrics`, `GET /:group`) for use in Sinatra, Roda, or plain Rack applications; opt-in via `require "rails_health_checks/rack/app"`; supports token auth, IP allowlist, custom auth block, result caching, and check groups; Rails-specific built-in checks (`:database`, `:cache`) require ActiveRecord/Rails in the stack but framework-agnostic checks (`:disk`, `:memory`, `:http`, `:redis`, `:smtp`) work in any Rack context
 
+### Changed
+- Relaxed Rails dependency from `>= 8.0` to `>= 7.1`; gem is now compatible with Rails 7.1, 7.2, and 8.x
+- Added `concurrent-ruby >= 1.1` as an explicit runtime dependency (was previously an implicit transitive dependency through Rails)
+- CI matrix expanded to test against Rails 7.1 and 7.2 on Ruby 3.3 and 3.4; Ruby 4.0 continues to test against Rails 8.x only
+
 ## [1.0.1] - 2026-06-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Relaxed Rails dependency from `>= 8.0` to `>= 7.1`; gem is now compatible with Rails 7.1, 7.2, and 8.x
 - Added `concurrent-ruby >= 1.1` as an explicit runtime dependency (was previously an implicit transitive dependency through Rails)
 - CI matrix expanded to test against Rails 7.1 and 7.2 on Ruby 3.3 and 3.4; Ruby 4.0 continues to test against Rails 8.x only
+- Removed `factory_bot_rails` dev dependency — no factories exist in this gem and no specs use FactoryBot
+- Removed explicit `rubocop-rails` dev dependency — it is a declared dependency of `rubocop-rails-omakase` and is installed transitively
 
 ## [1.0.1] - 2026-06-09
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem "sqlite3"
 # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
 gem "bundler-audit", require: false
 gem "rspec-rails"
-gem "rubocop-rails"
 gem "rubocop-rails-omakase", require: false
 gem "simplecov",      require: false
 gem "simplecov-json", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "sqlite3"
 
 # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
 gem "bundler-audit", require: false
-gem "factory_bot_rails"
 gem "rspec-rails"
 gem "rubocop-rails"
 gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,11 +100,6 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
-    factory_bot (6.6.0)
-      activesupport (>= 6.1.0)
-    factory_bot_rails (6.5.1)
-      factory_bot (~> 6.5)
-      railties (>= 6.1.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -315,7 +310,6 @@ DEPENDENCIES
   benchmark
   benchmark-ips
   bundler-audit
-  factory_bot_rails
   puma
   rails_health_checks!
   rspec-rails
@@ -354,8 +348,6 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  factory_bot (6.6.0) sha256=1fc1b3b5620ec980a6a27aec1b6ec8c250ca82962e970e8a40f93e8d388d4b89
-  factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,6 @@ DEPENDENCIES
   puma
   rails_health_checks!
   rspec-rails
-  rubocop-rails
   rubocop-rails-omakase
   simplecov
   simplecov-json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     rails_health_checks (1.0.1)
-      rails (>= 8.0)
+      concurrent-ruby (>= 1.1)
+      rails (>= 7.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -10,7 +10,6 @@ gem "puma"
 gem "sqlite3", "~> 1.7"
 
 gem "bundler-audit",          require: false
-gem "factory_bot_rails"
 gem "rspec-rails"
 gem "rubocop-rails"
 gem "rubocop-rails-omakase",  require: false

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rails", "~> 7.1.0"
+
+gemspec path: ".."
+
+gem "puma"
+gem "sqlite3", "~> 1.7"
+
+gem "bundler-audit",          require: false
+gem "factory_bot_rails"
+gem "rspec-rails"
+gem "rubocop-rails"
+gem "rubocop-rails-omakase",  require: false
+gem "simplecov",              require: false
+gem "simplecov-json",         require: false
+
+gem "benchmark",     require: false
+gem "benchmark-ips", require: false

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -11,7 +11,6 @@ gem "sqlite3", "~> 1.7"
 
 gem "bundler-audit",          require: false
 gem "rspec-rails"
-gem "rubocop-rails"
 gem "rubocop-rails-omakase",  require: false
 gem "simplecov",              require: false
 gem "simplecov-json",         require: false

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rails", "~> 7.2.0"
+
+gemspec path: ".."
+
+gem "puma"
+gem "sqlite3", "~> 2.0"
+
+gem "bundler-audit",          require: false
+gem "factory_bot_rails"
+gem "rspec-rails"
+gem "rubocop-rails"
+gem "rubocop-rails-omakase",  require: false
+gem "simplecov",              require: false
+gem "simplecov-json",         require: false
+
+gem "benchmark",     require: false
+gem "benchmark-ips", require: false

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -10,7 +10,6 @@ gem "puma"
 gem "sqlite3", "~> 2.0"
 
 gem "bundler-audit",          require: false
-gem "factory_bot_rails"
 gem "rspec-rails"
 gem "rubocop-rails"
 gem "rubocop-rails-omakase",  require: false

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -11,7 +11,6 @@ gem "sqlite3", "~> 2.0"
 
 gem "bundler-audit",          require: false
 gem "rspec-rails"
-gem "rubocop-rails"
 gem "rubocop-rails-omakase",  require: false
 gem "simplecov",              require: false
 gem "simplecov-json",         require: false

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -11,7 +11,6 @@ gem "sqlite3"
 
 gem "bundler-audit",          require: false
 gem "rspec-rails"
-gem "rubocop-rails"
 gem "rubocop-rails-omakase",  require: false
 gem "simplecov",              require: false
 gem "simplecov-json",         require: false

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -10,7 +10,6 @@ gem "puma"
 gem "sqlite3"
 
 gem "bundler-audit",          require: false
-gem "factory_bot_rails"
 gem "rspec-rails"
 gem "rubocop-rails"
 gem "rubocop-rails-omakase",  require: false

--- a/lib/rails_health_checks/check_registry.rb
+++ b/lib/rails_health_checks/check_registry.rb
@@ -69,7 +69,9 @@ module RailsHealthChecks
       if defined?(ActiveSupport::Notifications)
         ActiveSupport::Notifications.instrument("health_check.rails_health_checks", &block)
       else
+        # :nocov:
         yield nil
+        # :nocov:
       end
     end
 

--- a/rails_health_checks.gemspec
+++ b/rails_health_checks.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
     Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   end
 
-  spec.add_dependency 'rails', '>= 8.0'
+  spec.add_dependency 'rails', '>= 7.1'
+  spec.add_dependency 'concurrent-ruby', '>= 1.1'
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -7,7 +7,7 @@ require 'rails_health_checks'
 
 module Dummy
   class Application < Rails::Application
-    config.load_defaults 8.0
+    config.load_defaults Rails::VERSION::MAJOR >= 8 ? 8.0 : 7.1
     config.eager_load = false
     config.cache_store = :memory_store
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,5 +10,5 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[7.1].define(version: 0) do
 end

--- a/spec/rack/app_spec.rb
+++ b/spec/rack/app_spec.rb
@@ -198,6 +198,32 @@ RSpec.describe RailsHealthChecks::Rack::App do
 
       expect(response.status).to eq(401)
     end
+
+    it "returns 401 for an invalid IP address" do
+      response = browser.get("/", "REMOTE_ADDR" => "not-an-ip")
+
+      expect(response.status).to eq(401)
+    end
+  end
+
+  describe "custom block authentication" do
+    before do
+      RailsHealthChecks.configure do |config|
+        config.authenticate { |request| request.env["HTTP_X_INTERNAL"] == "true" }
+      end
+    end
+
+    it "returns 200 when the block returns truthy" do
+      response = browser.get("/", "HTTP_X_INTERNAL" => "true")
+
+      expect(response.status).to eq(200)
+    end
+
+    it "returns 401 when the block returns falsy" do
+      response = browser.get("/")
+
+      expect(response.status).to eq(401)
+    end
   end
 
   describe "result caching" do


### PR DESCRIPTION
## Summary

- Relaxes the Rails dependency from `>= 8.0` to `>= 7.1`; gem now supports Rails 7.1, 7.2, and 8.x
- Adds `concurrent-ruby >= 1.1` as an explicit runtime dependency (was an implicit transitive dep through Rails)
- Expands CI matrix with `gemfiles/rails_7_1.gemfile` and `gemfiles/rails_7_2.gemfile`; Ruby 4.0 tests Rails latest only
- Makes `config.load_defaults` version-aware in the dummy app so it boots under any supported Rails version
- Removes unused `factory_bot_rails` dev dependency — no factories exist and no specs use FactoryBot
- Removes explicit `rubocop-rails` dev dependency — pulled in transitively by `rubocop-rails-omakase`

## Test plan

- [ ] `bundle exec rake` passes locally (lint + audit + 220 specs)
- [ ] CI passes on all matrix combinations: Rails 7.1/7.2/8.0/latest × Ruby 3.3/3.4, plus Rails latest on Ruby 4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)