### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-12
+
 ### Added
 - Readiness endpoint `GET /health/ready` (and `HEAD`) — runs all configured dependency checks and returns `200 OK` / `503 Service Unavailable` as plain text; the path is configurable via `config.readiness_path` (default: `"ready"`)
 - README: Kubernetes and load balancer wiring examples, step-by-step cascade failure scenario, per-environment endpoint guidance, and Upgrading section for the v1.1.x → v1.2.x breaking change

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_health_checks (1.1.0)
+    rails_health_checks (1.2.0)
       concurrent-ruby (>= 1.1)
       rails (>= 7.1)
 
@@ -388,7 +388,7 @@ CHECKSUMS
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
-  rails_health_checks (1.1.0)
+  rails_health_checks (1.2.0)
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701

--- a/lib/rails_health_checks/version.rb
+++ b/lib/rails_health_checks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsHealthChecks
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
## v1.2.0

### Added
- Readiness endpoint `GET /health/ready` (and `HEAD`) — runs all configured dependency checks, returns plain text `200`/`503`; path configurable via `config.readiness_path` (default: `"ready"`)
- README: Kubernetes and load balancer wiring examples, cascade failure walkthrough, Upgrading section

### Changed (Breaking)
- `GET /health/live` no longer runs dependency checks — returns `200 OK` whenever the process is alive; authentication skipped so k8s/LB probes work without credentials. Switch to `/health/ready` for dependency checks.

## Checklist
- [x] Version bumped to `1.2.0`
- [x] CHANGELOG `[Unreleased]` → `[1.2.0] - 2026-06-12`
- [x] Full test suite passing (227 examples, 0 failures, 100% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)