### PR TITLE
fix: point Codecov upload at processed coverage.json to honour :nocov: exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,4 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/coverage.json


### PR DESCRIPTION
## Problem

Codecov was showing line 73 of `check_registry.rb` (`yield nil`) as uncovered even though it is wrapped in `# :nocov:` markers. The root cause: the `codecov-action` was auto-detecting `.resultset.json` (Ruby's raw coverage data), where `# :nocov:` lines appear as `0` hits rather than `nil` (excluded). SimpleCov's `# :nocov:` processing only runs when SimpleCov generates its own reports.

## Fix

Add `files: coverage/coverage.json` to point the upload at the file generated by `simplecov-json`, which is the post-processed output where `# :nocov:` lines are already excluded.

## Test plan

- [ ] CI passes
- [ ] Codecov no longer reports a missed line in `check_registry.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)